### PR TITLE
依存更新が壊れていないか見る CI を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# 依存を更新したときに壊れていないかを見るための最低限のチェック。
+# Dependabot の PR にもこれが走るので、更新して安全かどうかが分かる。
+#
+# 配布元: CALIL/workflows の templates/ci-npm.yml
+# 直すときは配布元を直して scripts/sync_checks.py で配ってください。
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+# 同じブランチで新しい push があったら、古い実行は止める
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: ビルドとテスト
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          # .nvmrc / package.json の engines があればそれに従う。
+          # 無ければ LTS を使う。
+          node-version-file: ${{ hashFiles('.nvmrc') != '' && '.nvmrc' || 'package.json' }}
+          cache: npm
+
+      # package-lock.json どおりに入れる。lock がずれていればここで落ちる。
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,13 @@ jobs:
       - name: Install
         run: npm ci
 
+      # ここだけテンプレートから変えている。
+      #
+      # このリポジトリの npm run build は
+      #   npm run copy && npx cordova run android
+      # で、run は端末かエミュレータへアプリを送り込む操作。CI では成立しない。
+      #
+      # copy が web 側の組み立て一式（browserify → sass → css/fonts/jsons）に
+      # あたるので、依存を更新して壊れていないかはこれで分かる。
       - name: Build
-        run: npm run build
+        run: npm run copy


### PR DESCRIPTION
## このPRでやること

依存を更新したときに壊れていないかを見る **CI を追加**します。

```
npm ci
npm run build
```

## なぜ必要か

いま Dependabot のオープン PR は **447件**ありますが、
そのうち **372件（83%）には実質的な CI がありません**。
GitGuardian の機密情報スキャンは動いていますが、
それは「依存を上げて壊れていないか」の検証にはなりません。

このリポジトリには **5件**の Dependabot PR が溜まっており、
検証できないままマージするか、放置するかの二択になっています。

CI を入れれば Dependabot の PR にもこれが走るので、
**緑なら安心してマージでき、赤ければ何が壊れるか分かります**。

## このPR自体が検証になります

雛形には `on: pull_request` があるので、**このPRでこの CI が実際に走ります**。

- **緑になれば**、この設定で通ることが確かめられたということです
- **赤ければ**マージしません。何が通らないかが分かるので、そこから直します

`npm ci` / `uv sync --frozen` を使うため、
**ロックファイルがずれていればそこで落ちます**（それも検出したい状態です）。

## 配布元

雛形は [CALIL/workflows](https://github.com/CALIL/workflows) の
`templates/ci-npm.yml` で管理しています。内容を変えるときは配布元を直してください。
