### PR TITLE
ol の import をファイル名どおりの大文字小文字にする

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,9 +2,9 @@ import {transform, transformExtent} from 'ol/proj';
 import {easeOut, elastic} from 'ol/easing';
 import Map from 'ol/Map';
 import {getDistance} from 'ol/sphere';
-import View from 'ol/view';
-import XYZ from 'ol/source/xyz';
-import Tile from 'ol/layer/tile';
+import View from 'ol/View';
+import XYZ from 'ol/source/XYZ';
+import Tile from 'ol/layer/Tile';
 
 import Kanikama from './libs/kanikama.js';
 import Kanimarker from './libs/kanimarker.js';

--- a/src/libs/kanilayer.js
+++ b/src/libs/kanilayer.js
@@ -6,7 +6,7 @@
  */
 
 import LayerGroup from 'ol/layer/Group';
-import XYZ from 'ol/source/xyz';
+import XYZ from 'ol/source/XYZ';
 import VectorSource from 'ol/source/Vector';
 import TileLayer from 'ol/layer/Tile';
 import Style from 'ol/style/Style';


### PR DESCRIPTION
CI 追加 PR #132 のビルドが落ちている原因のひとつです。

```
Error: Can't walk dependency graph: Cannot find module 'ol/view' from src/app.js
```

## 中身

ol の実体は `View.js` / `XYZ.js` / `Tile.js` で、小文字では解決できません。**Windows と macOS はファイル名の大小を区別しないため手元では通り、Linux では落ちます。** CI（ubuntu）で初めて表面化しました。

| ファイル | 直したもの |
|---|---|
| `src/app.js` | `ol/view` → `ol/View` |
| | `ol/source/xyz` → `ol/source/XYZ` |
| | `ol/layer/tile` → `ol/layer/Tile` |
| `src/libs/kanilayer.js` | `ol/source/xyz` → `ol/source/XYZ` |

同じ `kanilayer.js` の中で `ol/layer/Tile` は正しく書けており、表記が混ざっていました。ほかの ol の import（`ol/proj` `ol/easing` `ol/Map` `ol/sphere` `ol/format` `ol/style/*` `ol/geom/*` など）は実体と一致しています。

## 確認

```
npm run copy   通過（browserify → sass → css/fonts/jsons のコピー）
```

`www/css/app.css` は再生成しても中身が変わらないこと（改行コードのみ）を確認しています。

## #132 を緑にするにはもう1つ要ります

`npm run build` は `npm run copy && npx cordova run android` です。**`run` は端末かエミュレータへアプリを送り込む操作**で、CI では成立しません。#132 のほうにコメントしています。