### PR TITLE
geolib を名前付き import にする

### DIFF
--- a/src/libs/kanikama.js
+++ b/src/libs/kanikama.js
@@ -7,7 +7,10 @@
 
  */
 
-import geolib from 'geolib'
+// 名前付きで取る。geolib 3 は default を持たないので
+// import geolib from 'geolib' だと undefined になる。
+// 名前付きなら 2 でも 3 でも動く。
+import { getDistance } from 'geolib'
 
 /**
  * ビーコンオブジェクトが同じかどうか評価する
@@ -277,7 +280,7 @@ export default class Kanikama {
       if (floor._runtime.beacons.length > 0) {
         floor._runtime.beacons.sort((a, b) => b.rssi - a.rssi);
         for (const b of floor._runtime.beacons) {
-          const distance = geolib.getDistance(b, floor._runtime.beacons[0]);
+          const distance = getDistance(b, floor._runtime.beacons[0]);
           if (distance <= effectiveRange) {
             rssiSum += b.rssi;
             rssiCount++;


### PR DESCRIPTION
Dependabot の **#130（geolib 2.0.24 → 3.3.14）は、このままマージすると実行時に落ちます。** 先に直しておきます。

## 何が起きるか

geolib 3 は `__esModule` を立てているのに `default` を持ちません。そのため `import geolib from 'geolib'` が `undefined` になります。

```
TypeError: Cannot read properties of undefined (reading 'getDistance')
```

落ちるのは `kanikama.js` のフロア判定（最も強いビーコンの周囲3mの平均RSSIを出すところ）です。**ビルドは通ります**。このリポジトリの CI はビルドだけなので、CI が緑でも気づけません。

Babel（preset-env / `modules: commonjs`）で実際に動かして確認しました。

```
geolib 3 + default import    TypeError: Cannot read properties of undefined
geolib 3 + 名前付き import   OK
geolib 2 + 名前付き import   OK
```

名前付きなら 2 でも 3 でも動きます。2 は `module.exports` のオブジェクトに `getDistance` が生えていて、Babel の名前付き import はそこから読むためです。

## 距離の値

念のため 2 と 3 で比べました。

| 距離 | v2 | v3 |
|---|---|---|
| 近距離 | 14 m | 14 m |
| 同一地点 | 0 m | 0 m |
| 4.5 km | 4529 m | 4543 m |

遠距離で 0.3% ずれますが、ここの用途は「3m 以内のビーコンか」の判定（`effectiveRange = 3`）なので影響しません。ビーコンの座標は `latitude` / `longitude` で、どちらのバージョンでも受け付けます。

## 確認

```
npm run copy   通過
```

これをマージしたあとなら #130 を入れて大丈夫です。