### PR TITLE
Babel のメジャー更新を Dependabot から外す

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,22 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 30
+    ignore:
+      # Babel 8 にはまだ上げられない。ビルドが browserify + babelify で、
+      # babelify の最新 10.0.0 が peer に @babel/core ^7.0.0 を要求する。
+      # @babel/core だけ 8 にすると npm ci が ERESOLVE で落ちる（#129 で実測）。
+      #
+      # 移行にはこれらも要る。単なるバージョン更新では済まない。
+      #   - babelify が Babel 8 に対応すること
+      #   - @babel/polyfill をやめること（Babel 8 で削除。現状どこからも参照が無い）
+      #   - @babel/plugin-proposal-class-properties をやめること
+      #     （Babel 8 では preset-env に入っていて、この名前のパッケージは無い）
+      #
+      # 対応後にこの ignore を外してください。
+      - dependency-name: "@babel/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "babelify"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         patterns:


### PR DESCRIPTION
#129（`@babel/core` 7.29.6 → 8.0.1）が **`npm ci` の時点で落ちました**。CI を入れたおかげで分かったものです。

```
npm error Could not resolve dependency:
npm error peer @babel/core@"^7.0.0-0" from @babel/plugin-proposal-class-properties@7.18.6
npm error Conflicting peer dependency: @babel/core@7.29.7
```

## Babel 8 にはまだ上げられません

ビルドが browserify + babelify で、**babelify の最新 10.0.0 が peer に `@babel/core ^7.0.0` を要求します**。Babel 8 対応版がまだありません。

移行にはこれらも要ります。バージョン更新では済みません。

- babelify が Babel 8 に対応すること
- `@babel/polyfill` をやめること — Babel 8 で削除されています（**現状どこからも参照が無い**ので、これは今すぐ外せます）
- `@babel/plugin-proposal-class-properties` をやめること — Babel 8 では preset-env に入っていて、この名前のパッケージ自体がありません

## この PR でやること

`@babel/*` と `babelify` のメジャー更新を `ignore` に入れます。条件が揃うまで毎週同じ PR が出て落ち続けるためです。対応後に ignore を消せば再開します。

#129 はこの理由でクローズします。