### PR TITLE
Android のビルドを CI で確認する

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,113 @@
+name: Android ビルド
+
+# Android の APK が組み上がるところまで通す。
+#
+# ci.yml は web 側（browserify / sass）までしか見ていない。
+# cordova のプラグインや Gradle 側が壊れても気づけないので分けてある。
+#
+# 実機やエミュレータは使わない。cordova build android は端末を要求しないが、
+# npm run build（cordova run android）は要求するので混同しないこと。
+#
+# ランナーは ske-v2。ske-v1 の summerwind 版 actions-runner-controller は
+# 2026-06-03 に gha-runner-scale-set へ移行済みで、
+# runs-on: [self-hosted, Linux] では拾われない。
+# → CALIL/ske-v2 の kube/actions-runner/README.md
+#
+# ランナーの image は ghcr.io/actions/actions-runner で、
+# ubuntu-latest と違って JDK も Android SDK も入っていない。
+# どちらも毎回入れる。
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: android-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: APK を組む
+    runs-on: ske-v2
+    # SDK の取得と Gradle の初回実行で伸びる。キャッシュが温まれば10分程度
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7 # zizmor: ignore[cache-poisoning]
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      # AGP 8.10（cordova-android 15）が JDK 17 以上を要求する
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+        with:
+          packages: >-
+            platform-tools
+            platforms;android-36
+            build-tools;36.0.0
+
+      # ランナーは毎回使い捨てなので、Gradle の取得物は自分で持ち越す
+      - name: Gradle のキャッシュ
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('package-lock.json', 'config.xml') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Install
+        run: npm ci
+
+      # www/ を作る。これが無いと空のアプリが焼き上がる
+      - name: web 側をビルド
+        run: npm run copy
+
+      # config.xml と package.json の cordova.plugins から復元する。
+      # platforms/android は .gitignore されているので毎回作り直し
+      - name: Android プラットフォームを用意
+        run: npx cordova prepare android
+
+      - name: 要件の確認
+        run: npx cordova requirements android
+
+      # デバッグビルド。署名は要らない（release は keystore が要るので CI ではやらない）
+      - name: APK を組む
+        run: npx cordova build android --debug
+        env:
+          # ske-v2 は memory limit 8Gi。Gradle と Kotlin に取らせすぎると
+          # OOMKilled でランナーごと落ちる
+          GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g -Dorg.gradle.daemon=false
+
+      - name: できたものを確認
+        run: |
+          set -euo pipefail
+          apk=$(find platforms/android/app/build/outputs/apk -name '*.apk' | head -1)
+          [ -n "$apk" ] || { echo "APK が見つからない"; exit 1; }
+          ls -lh "$apk"
+          echo "APK_PATH=$apk" >> "$GITHUB_ENV"
+
+      - name: APK を残す
+        uses: actions/upload-artifact@v7
+        with:
+          name: sabatomap-debug-apk
+          path: ${{ env.APK_PATH }}
+          retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,15 +64,14 @@ jobs:
             platforms;android-36
             build-tools;36.0.0
 
-      # ランナーは毎回使い捨てなので、Gradle の取得物は自分で持ち越す
-      - name: Gradle のキャッシュ
-        uses: actions/cache@v4
+      # cordova は wrapper を「システムの gradle で」作る。
+      # ubuntu-latest には最初から入っているが、このランナーには無いので入れる。
+      # 版は cordova-android の cdv-gradle-config-defaults.json に合わせてある。
+      # ランナーは毎回使い捨てなので、取得物の持ち越しもこれに任せる。
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('package-lock.json', 'config.xml') }}
-          restore-keys: gradle-${{ runner.os }}-
+          gradle-version: '8.14.2'
 
       - name: Install
         run: npm ci

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,28 @@
+# Actionsのセキュリティチェック(zizmor)の設定
+#
+# unpinned-uses: uses: の書き方をどこまで厳しくするか
+#
+#   GitHub 公式(actions/*)と自社(CALIL/*)は、タグやブランチでの指定を許容します。
+#   これらの参照先を差し替えられるのは GitHub 自身か自社だけで、
+#   第三者が公開するアクションとはリスクの質が違うためです。
+#
+#   それ以外はすべてコミットSHAでの固定を必須にします。第三者のアクションは
+#   タグを後から別のコミットに付け替えられるため、タグ指定だと
+#   「レビューしたコードとは違うものが動く」ことが起こりえます。
+#
+#   第三者のアクションを追加するときの書き方:
+#     - uses: foo/bar@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+#   SHA はタグのページか `gh api repos/foo/bar/commits/v1.2.3 --jq .sha` で取れます。
+#   Dependabot はこの形式を認識し、更新時に SHA とコメントの両方を書き換えます。
+#
+# 個別に許容したい指摘は、ワークフロー側の該当行に次のコメントを付けて除外します:
+#   # zizmor: ignore[ルール名]
+#
+# 設定の詳細: https://docs.zizmor.sh/configuration/
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "actions/*": ref-pin
+        "CALIL/*": ref-pin
+        "*": hash-pin


### PR DESCRIPTION
`ci.yml` は web 側（browserify / sass）までしか見ていません。cordova のプラグインや Gradle 側が壊れても気づけないので、**APK が組み上がるところまで**を別のワークフローにしました。

実機やエミュレータは使いません。`cordova build android` は端末を要求しません（`npm run build` = `cordova run android` のほうは要求します）。

## ランナーは ske-v2 にしました

ご指定は ske-v1 でしたが、**ske-v1 の summerwind 版 actions-runner-controller は 2026-06-03 に gha-runner-scale-set へ移行済み**です。`runs-on: [self-hosted, Linux]` では拾われず、ジョブがタイムアウトまで待たされます。

> | 方式 | gha-runner-scale-set（`AutoscalingRunnerSet`、JIT エフェメラル runner） |
> | runs-on | `ske-v2`（= runnerScaleSetName） |
>
> — [CALIL/ske-v2 `kube/actions-runner/README.md`](https://github.com/CALIL/ske-v2/blob/main/kube/actions-runner/README.md)

ハードウェアは v1 の 16 台をそのまま流用しているので、実体は同じです。`unitrad-view` や `citation-pipeline` も `runs-on: ske-v2` を使っています。

`ske-v2-large` は使っていません。あちらは `maxRunners: 1` でバッチ向けなので、PR ごとに走るビルドで占有すると他が詰まります。

## 中身

ランナーの image は `ghcr.io/actions/actions-runner` で、**`ubuntu-latest` と違って JDK も Android SDK も入っていません**。どちらも毎回入れます。

| | 値 | 根拠 |
|---|---|---|
| JDK | 17 | cordova-android 15 の AGP 8.10 が 17 以上を要求 |
| SDK | `platforms;android-36` / `build-tools;36.0.0` | config.xml の `targetSdkVersion 36` と `cdv-gradle-config-defaults.json` の `MIN_BUILD_TOOLS_VERSION` |
| `GRADLE_OPTS` | `-Xmx3g`、daemon なし | ske-v2 の memory limit が 8Gi。取らせすぎると OOMKilled でランナーごと落ちる |

ランナーは使い捨てなので、Gradle の取得物は `actions/cache` で持ち越します。初回は SDK と Gradle の取得で伸びるため timeout は 45 分にしてあります。

できた APK は artifact に残します（14日）。

`.github/zizmor.yml` も置きました（他リポジトリと同じもの）。これが無いと `actions/*` もハッシュ固定を求められます。zizmor は指摘ゼロです。

## この PR 自体が最初のテストです

ワークフローは `pull_request` でも走るので、**この PR で実際にビルドが通るか分かります**。手元に Android SDK が無いため、そこまでは確認できていません。落ちたら直します。