### PR TITLE
ci: dependabot.ymlにgithub-actionsエコシステムを追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,31 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions (.github/workflows)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+    # github-actions では semver-major-days は使えない。
+    # 指定すると設定ファイル全体が弾かれ、Dependabot がまったく動かなくなる。
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 変更内容

`.github/dependabot.yml` に `github-actions` エコシステムを追加する。

## 背景

CALIL org 横断でActions/Dependabotの設定状況を棚卸しした結果、本リポジトリは `.github/workflows/` を持つが dependabot.yml に `github-actions` エコシステムが設定されておらず、Actions自体のバージョン更新がDependabotの対象外になっていた。