### PR TITLE
chore: del を外して clean を node:fs/promises の rm に置き換える

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,6 +1,6 @@
 import gulp from 'gulp';
-// 名前付きで取る。del 8 は default を持たない
-import { deleteAsync } from 'del';
+// 削除は Node 標準で足りるので del は使わない
+import { rm } from 'node:fs/promises';
 import dartSass from 'sass';
 import gulpSass from 'gulp-sass';
 const sass = gulpSass(dartSass);
@@ -47,7 +47,13 @@ gulp.task('sass', function () {
 
 // 削除の完了を待ってから done() を呼ぶ。
 // 以前は待たずに done() していたので、消し終わる前に次へ進んでいた
-gulp.task('clean', () => deleteAsync(['platforms/ios/www/**']));
+//
+// del の頃は 'platforms/ios/www/**' というグロブを渡していたので、
+// 中身だけを消してディレクトリ自体は空のまま残していた。fs.rm は
+// ディレクトリごと消すが、cordova prepare が updateWww で作り直すため
+// 問題ない（cordova-common の FileUpdater が cpSync を recursive で呼ぶ）。
+// force: true があるので platforms/ios が無い状態でも失敗しない。
+gulp.task('clean', () => rm('platforms/ios/www', { recursive: true, force: true }));
 gulp.task('watch', (done) => {
     gulp.watch(['src/*.js', 'src/*.jsx', 'src/*.sass'], ['buildjs', 'sass']);
     done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "cordova-plugin-inappbrowser": "^7.0.0",
         "cordova-plugin-network-information": "^3.1.0",
         "core-js": "^3.49.0",
-        "del": "^8.0.1",
         "gulp": "^5.0.0",
         "gulp-postcss": "^10.0.0",
         "gulp-replace": "^1.0.0",
@@ -2763,19 +2762,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -5447,98 +5433,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/del": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-8.0.1.tgz",
-      "integrity": "sha512-gPqh0mKTPvaUZGAuHbrBUYKZWBNAeHG7TU3QH5EhVwPMyKvmfJaNXhcD2jTcXsJRRcffuho4vaYweu80dRrMGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globby": "^14.0.2",
-        "is-glob": "^4.0.3",
-        "is-path-cwd": "^3.0.0",
-        "is-path-inside": "^4.0.0",
-        "p-map": "^7.0.2",
-        "presentable-error": "^0.0.1",
-        "slash": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
-        "path-type": "^6.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/del/node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/path-type": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -7544,19 +7438,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-path-cwd": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
-      "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -9479,19 +9360,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/presentable-error": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/presentable-error/-/presentable-error-0.0.1.tgz",
-      "integrity": "sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/proc-log": {
       "version": "6.1.0",
@@ -11526,19 +11394,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unique-string": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "cordova-plugin-inappbrowser": "^7.0.0",
     "cordova-plugin-network-information": "^3.1.0",
     "core-js": "^3.49.0",
-    "del": "^8.0.1",
     "gulp": "^5.0.0",
     "gulp-postcss": "^10.0.0",
     "gulp-replace": "^1.0.0",


### PR DESCRIPTION
## 何を

`gulpfile.babel.js` の `clean` タスクでしか使っていなかった `del` を外し、`node:fs/promises` の `rm` に置き換えました。

```diff
-// 名前付きで取る。del 8 は default を持たない
-import { deleteAsync } from 'del';
+// 削除は Node 標準で足りるので del は使わない
+import { rm } from 'node:fs/promises';

-gulp.task('clean', () => deleteAsync(['platforms/ios/www/**']));
+gulp.task('clean', () => rm('platforms/ios/www', { recursive: true, force: true }));
```

`devDependencies` からも `del` を削除しています。

## なぜ

`del` の用途はこの1箇所だけで、渡していたパターンも `platforms/ios/www/**` というディレクトリ1つ分のグロブでした。Node の標準機能で置き換えられます。

`cordova-ios` 自身も `lib/clean.js` で `fs.rmSync(path, { recursive: true, force: true })` を使っており、上流と同じ書き方になります。

**gulp 構成そのものには手を入れていません。** esbuild 移行は別タスクなので、そちらで書き直される前提でも差分が邪魔にならないよう `clean` の1行に閉じています。

## 挙動の差（2点あります）

グロブを単純なパス指定に変えたので、完全に同一ではありません。フィクスチャを作って `del` 版と `fs.rm` 版の両方を実行し、実際の残り方を突き合わせて確認しました。

| | `del`（変更前） | `fs.rm`（変更後） |
|---|---|---|
| `www/index.html` `www/js/` `www/sub/` などの中身 | 消える | 消える |
| `platforms/ios/www` ディレクトリ自体 | **空のまま残る** | **消える** |
| `www` 直下のドットファイル（`.DS_Store` など） | **残る** | **消える** |
| 兄弟の `platforms/ios/config.xml` `platforms/ios/cordova/` | 残る | 残る |

いずれも問題ないと判断しました。

1. **ディレクトリ自体が消える件**: `cordova prepare` の `updateWww` が `cordova-common` の `FileUpdater.mergeAndUpdateDir` を呼び、対象ディレクトリが無い場合は `fs.cpSync(source, target, { recursive: true })` で作り直します（`cordova-common` 6.0.0 の `src/FileUpdater.js` で確認）。`www` ごと消えていても復元されます
2. **ドットファイルが消える件**: `del` は `globby` の既定が `dot: false` なので `www` 直下のドットファイルを消し残していました。むしろこちらが妥当な挙動です

`force: true` があるので `platforms/ios` が存在しない状態（クローン直後）でも失敗しません。

## どう検証したか

Windows / Node 24.15.0 / npm 11.17.0 で実施しました。

**このリポジトリで実際に実行したもの**

| 確認したこと | 結果 |
|---|---|
| `npm ci`（`--ignore-scripts`） | 成功（896 packages） |
| `npm run copy`（CI の Build ステップと同じ） | 成功。browserify → sass → copy_css → copy_fonts → copy_jsons がすべて完走 |
| `platforms/ios/www` にフィクスチャを置いて `npx gulp clean` | 成功。`www` 配下が消え、兄弟の `config.xml` `cordova/` と追跡対象の `platforms/platforms.json` は無傷 |
| `platforms/ios/www` が無い状態で `npx gulp clean` | 成功（終了コード 0） |
| `platforms/` ごと無い状態で `npx gulp clean` | 成功。空ディレクトリを作ってしまうこともなし |
| `npx gulp --tasks` | 6タスクすべて従来どおり登録される |
| `del` の残存参照 | 0件 |

**変更前の `del` の挙動**は、スクラッチ領域に `del` 8.0.1 と gulp 5 だけを入れた砂場を作り、同じフィクスチャに対して変更前の `gulpfile.babel.js` を走らせて実測しました。上の表の「変更前」列はその実測値です。

## package-lock.json

`npm install --package-lock-only --ignore-scripts` で更新しました。node_modules を作らないので cordova のフックは動きません。

- 差分は **145行の削除のみで、追加行は0**。消えたのは `del` とその専用の推移的依存 10件（`globby` `ignore` `is-path-inside` `path-type` `slash` `is-path-cwd` `presentable-error` `unicorn-magic` `@sindresorhus/merge-streams`）だけです
- 他プラットフォーム向けの optional 依存は**変更前後とも23件で増減なし**。`lockfileVersion` も 3 のままです
- `npm ci --dry-run` で `package.json` との整合を確認済み

## 積み残し

- **`cordova prepare` / `cordova build ios` は実行していません。** iOS のツールチェーン（Xcode）が Windows の手元に無いためです。「`www` を消しても `cordova prepare` が作り直す」の根拠は `cordova-common` のソース読みと、`cordova-ios` 自身が同じ `fs.rmSync` を使っている事実によるもので、実機・実ビルドでの確認ではありません
- 検証で使ったフィクスチャ（`platforms/ios/`）は削除済みです。`platforms/ios` は `.gitignore` 済みで、コミットには `gulpfile.babel.js` `package.json` `package-lock.json` の3ファイルしか含まれていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SecR8hdLdUCNr4dCXsweAk
