### PR TITLE
refactor: superagent を fetch に置き換える

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,13 @@ cordova prepare
    - 図書カタログ用Unitrad APIとのインターフェース
    - 本を物理的な棚の位置にマッピング
    - フロアプラン上でターゲット棚をハイライト
+   - **通信は `fetch` のみ。** 2026-08-15 に superagent を撤去しました。
+     `polling` は `timeout=10` を渡しますが、これは**サーバ側のロングポーリングの指定**で
+     クライアントの待ち時間ではありません。「更新なし」はレスポンスが `null` で返ります
+   - `fetchMapping` は**どこからも呼ばれていません**（unitrad-ui 由来の名残）。
+     さばとマップの棚マッピングは `sabatomap-mapper.calil.jp` を使います。
+     `normalizeQuery` / `isEmptyQuery` / `isEqualQuery` も app 側からは未使用で、
+     テストが挙動を固定しているだけです
 
 ### データフロー
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "geolib": "^3.3.14",
         "ol": "^5.3.3",
         "react": "^19.2.8",
-        "react-dom": "^19.2.8",
-        "superagent": "^10.3.0"
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
         "autoprefixer": "^10.5.4",
@@ -755,18 +754,6 @@
         "lodash": "^4.17.15"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1270,15 +1257,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@paralleldrive/cuid2": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
-      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -2213,12 +2191,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
-    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2270,12 +2242,6 @@
       "dependencies": {
         "lodash": "^4.17.14"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.5.4",
@@ -2836,18 +2802,6 @@
       "dev": true,
       "license": "Apache 2.0"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/common-ancestor-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
@@ -2856,15 +2810,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/compressible": {
@@ -2993,12 +2938,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
-      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "license": "MIT"
     },
     "node_modules/cordova": {
@@ -3773,6 +3712,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3806,15 +3746,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -3868,16 +3799,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dezalgo": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
-      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
       }
     },
     "node_modules/dir-glob": {
@@ -4033,21 +3954,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4263,12 +4169,6 @@
       "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
       "license": "MIT"
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "license": "MIT"
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4322,39 +4222,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/formidable": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
-      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
-      "license": "MIT",
-      "dependencies": {
-        "@paralleldrive/cuid2": "^2.2.2",
-        "dezalgo": "^1.0.4",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -4596,21 +4463,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5511,6 +5363,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -7377,26 +7230,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/superagent": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
-      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.3.1",
-        "cookiejar": "^2.1.4",
-        "debug": "^4.3.7",
-        "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.5",
-        "formidable": "^3.5.4",
-        "methods": "^1.1.2",
-        "mime": "2.6.0",
-        "qs": "^6.14.1"
-      },
-      "engines": {
-        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "geolib": "^3.3.14",
     "ol": "^5.3.3",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8",
-    "superagent": "^10.3.0"
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
     "autoprefixer": "^10.5.4",

--- a/src/api.js
+++ b/src/api.js
@@ -8,20 +8,36 @@
 
  */
 
-import request from 'superagent';
-
 const ENDPOINT = 'https://unitrad.calil.jp/v1/';
 const FIELDS = ['free', 'title', 'author', 'publisher', 'isbn', 'ndc', 'year_start', 'year_end', 'region'];
 
 
 /**
  * Unitrad APIにアクセスするための共通関数
- * @param command APIのコマンド
- * @returns {Object}
+ *
+ * 以前は superagent の `.query(obj).end(cb)` だった。fetch に寄せたのは
+ * superagent を落とすため。挙動は次の3点で揃えてある。
+ *   - 2xx 以外は失敗として扱う（superagent の .end() が err を立てるのと同じ）
+ *   - レスポンスは JSON としてパースする
+ *   - polling が「更新なし」を res.body === null で判定していたので、
+ *     空のレスポンスは null を返す
+ *
+ * @param command {String} APIのコマンド
+ * @param params {Object} クエリパラメータ
+ * @returns {Promise<Object>} パース済みのレスポンス
  * @private
  */
-function _request(command) {
-  return request.get(ENDPOINT + command);
+function _request(command, params) {
+  const url = new URL(command, ENDPOINT);
+  for (let [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return fetch(url)
+    .then((res) => {
+      if (!res.ok) throw new Error(`${command}: ${res.status} ${res.statusText}`);
+      return res.text();
+    })
+    .then((text) => (text === '' ? null : JSON.parse(text)));
 }
 
 
@@ -47,32 +63,36 @@ export class api {
 
   search(query) {
     if (!this.killed) {
-      _request('search').query(stripQuery(query)).end((err, res) => {
-        if (!err) {
-          this.receive(res.body);
-        } else {
-          setTimeout(() => this.search(query), 1000)
-        }
-      })
+      // then に成功と失敗を両方渡す。catch にすると receive() が投げた例外まで
+      // 拾って再検索してしまい、superagent の .end(cb) と挙動が変わる
+      _request('search', stripQuery(query)).then(
+        (data) => this.receive(data),
+        () => setTimeout(() => this.search(query), 1000)
+      );
     }
   }
 
   polling() {
     if (!this.killed) {
-      _request('polling')
-        .query({
-          uuid: this.data.uuid,
-          version: this.data.version,
-          diff: 1,
-          timeout: 10
-        })
-        .end((err, res) => {
-          if (res.body === null) {
+      // timeout はサーバ側のロングポーリングの指定で、クライアントの待ち時間ではない
+      _request('polling', {
+        uuid: this.data.uuid,
+        version: this.data.version,
+        diff: 1,
+        timeout: 10
+      }).then(
+        (data) => {
+          if (data === null) {
             setTimeout(() => this.polling(), 100)
           } else {
-            this.receive(res.body)
+            this.receive(data)
           }
-        })
+        },
+        // 以前は err を見ずに res.body を触っていたので、通信が失敗すると
+        // res が undefined で TypeError になりポーリングが止まっていた。
+        // search と同じく間を置いて再試行する
+        () => setTimeout(() => this.polling(), 1000)
+      );
     }
   }
 
@@ -199,12 +219,14 @@ export function stripQuery(query) {
 
 /**
  * マッピングデータを取得する
+ *
+ * **このリポジトリでは誰も呼んでいない**（unitrad-ui 由来のコードの名残）。
+ * さばとマップの棚マッピングは sabatomap-mapper.calil.jp を使う。
+ *
  * @param region {String} リージョン
  * @param callback {Function} マッピングデータを受け取るコールバック関数
  */
 export function fetchMapping(region, callback) {
-  _request('mapping').query({'region': region}).end((err, res) => {
-    callback(res.body)
-  })
+  _request('mapping', {'region': region}).then(callback, console.error)
 }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,150 @@
+// src/api.js が superagent の .query(obj).end(cb) から fetch へ移ったので、
+// 揃えた挙動をここで固定する。
+//
+//   - クエリの組み立て（stripQuery が空を落としたうえで URL に載る）
+//   - 2xx 以外は失敗として扱い、search は1秒後に再試行する
+//   - polling は「更新なし」を null で判定して再試行する
+//   - 通信の失敗でポーリングが止まらない
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { api } from '../src/api.js';
+
+/** fetch のスタブ。res.text() を返すところまで本物に合わせる */
+const okText = (body) => Promise.resolve({
+  ok: true, status: 200, statusText: 'OK', text: () => Promise.resolve(body),
+});
+const failWith = (status) => Promise.resolve({
+  ok: false, status, statusText: 'Error', text: () => Promise.resolve(''),
+});
+
+const alive = [];
+afterEach(() => {
+  while (alive.length) alive.pop().kill();
+  // test/setup.js の既定に戻す
+  globalThis.fetch = () => new Promise(() => {});
+});
+
+/** 検索を走らせずに polling だけ試すためのインスタンス */
+function bareApi(callback, data) {
+  const a = Object.create(api.prototype);
+  a.killed = false;
+  a.callback = callback;
+  a.data = data;
+  alive.push(a);
+  return a;
+}
+
+const RESULT = { uuid: 'u1', version: 1, books: [], running: false };
+
+describe('search', () => {
+  it('空でないフィールドだけを URL に載せる', async () => {
+    const urls = [];
+    globalThis.fetch = (url) => { urls.push(String(url)); return okText(JSON.stringify(RESULT)); };
+
+    const received = [];
+    alive.push(new api({ free: 'ねこ', title: '', region: 'sabae' }, (d) => received.push(d)));
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toBe('https://unitrad.calil.jp/v1/search?free=%E3%81%AD%E3%81%93&region=sabae');
+    expect(received[0]).toEqual(RESULT);
+  });
+
+  it('2xx 以外なら再試行する', async () => {
+    let n = 0;
+    globalThis.fetch = () => {
+      n += 1;
+      return n === 1 ? failWith(503) : okText(JSON.stringify(RESULT));
+    };
+
+    const received = [];
+    alive.push(new api({ free: 'ねこ' }, (d) => received.push(d)));
+    // 再試行は 1000ms 後
+    await vi.waitFor(() => expect(received).toHaveLength(1), { timeout: 4000 });
+    expect(n).toBe(2);
+  });
+
+  it('通信そのものが失敗しても再試行する', async () => {
+    let n = 0;
+    globalThis.fetch = () => {
+      n += 1;
+      return n === 1 ? Promise.reject(new TypeError('Failed to fetch')) : okText(JSON.stringify(RESULT));
+    };
+
+    const received = [];
+    alive.push(new api({ free: 'ねこ' }, (d) => received.push(d)));
+    await vi.waitFor(() => expect(received).toHaveLength(1), { timeout: 4000 });
+    expect(n).toBe(2);
+  });
+
+  it('kill 後は結果を配らない', async () => {
+    let resolve;
+    globalThis.fetch = () => new Promise((r) => { resolve = r; });
+
+    const received = [];
+    const a = new api({ free: 'ねこ' }, (d) => received.push(d));
+    a.kill();
+    resolve({ ok: true, status: 200, statusText: 'OK', text: () => Promise.resolve(JSON.stringify(RESULT)) });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(received).toHaveLength(0);
+  });
+});
+
+describe('polling', () => {
+  it('null は「更新なし」なので再試行する', async () => {
+    const bodies = ['null', JSON.stringify({ uuid: 'u1', version: 2, books: [], running: false })];
+    const urls = [];
+    let n = 0;
+    globalThis.fetch = (url) => { urls.push(String(url)); return okText(bodies[n++]); };
+
+    const received = [];
+    bareApi((d) => received.push(d), { uuid: 'u1', version: 1, books: [] }).polling();
+
+    await vi.waitFor(() => expect(received).toHaveLength(1), { timeout: 4000 });
+    expect(n).toBe(2);
+    expect(urls[0]).toBe('https://unitrad.calil.jp/v1/polling?uuid=u1&version=1&diff=1&timeout=10');
+    expect(received[0].version).toBe(2);
+  });
+
+  it('通信の失敗で止まらない', async () => {
+    let n = 0;
+    globalThis.fetch = () => {
+      n += 1;
+      return n === 1
+        ? Promise.reject(new TypeError('Failed to fetch'))
+        : okText(JSON.stringify({ uuid: 'u1', version: 2, books: [], running: false }));
+    };
+
+    const received = [];
+    bareApi((d) => received.push(d), { uuid: 'u1', version: 1, books: [] }).polling();
+
+    await vi.waitFor(() => expect(received).toHaveLength(1), { timeout: 4000 });
+    expect(n).toBe(2);
+  });
+});
+
+describe('receive の差分適用', () => {
+  it('books_diff の insert と update を反映する', async () => {
+    globalThis.fetch = () => okText(JSON.stringify({
+      uuid: 'u1', version: 1, running: false,
+      books: [{ id: 'b1', title: '一冊目', holdings: [] }],
+    }));
+
+    const received = [];
+    const a = new api({ free: 'ねこ' }, (d) => received.push(d));
+    alive.push(a);
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    a.receive({
+      version: 2,
+      running: false,
+      books_diff: {
+        insert: [{ id: 'b2', title: '二冊目', holdings: [] }],
+        update: [{ _idx: 0, holdings: [100622] }],
+      },
+    });
+
+    expect(a.data.version).toBe(2);
+    expect(a.data.books.map((b) => b.id)).toEqual(['b1', 'b2']);
+    expect(a.data.books[0].holdings).toEqual([100622]);
+  });
+});

--- a/test/interop.test.js
+++ b/test/interop.test.js
@@ -9,15 +9,10 @@
 // 「何を import してどう使っているか」の契約をここに固定しておけば、
 // 実装側が受け方を変えたときに気づける。
 import { describe, it, expect } from 'vitest';
-import request from 'superagent';
 import { getDistance } from 'geolib';
 import { api, normalizeQuery, isEmptyQuery, isEqualQuery, stripQuery } from '../src/api.js';
 
 describe('CommonJS 依存の受け取り方', () => {
-  it('superagent は get を持つ', () => {
-    expect(typeof request.get).toBe('function');
-  });
-
   it('geolib の getDistance は関数', () => {
     expect(typeof getDistance).toBe('function');
     // 鯖江市図書館の敷地内で 0 より大きい距離が出る


### PR DESCRIPTION
ビルド構成のモダン化の第5段です。**ベースは #163**（下に #162 → #161 → #160）なので、下から順にご覧ください。

`src/api.js` の `_request()` が superagent の `.query(obj).end(cb)` を使っていた3箇所を `fetch` に置き換え、`superagent` を dependencies から外しました。`Search.jsx:50` と `api.js` の `getMap()` は既に `fetch` を使っていたので、これで通信経路が1つに揃います。

## 実測値

| | 前 | 後 |
|---|---|---|
| `www/js/all.js` | 671,013 バイト | 624,673 バイト（**-46,340**） |
| モジュール数 | 378 | 325 |

## 揃えた挙動

- **2xx 以外は失敗として扱う。** superagent の `.end(cb)` が非 2xx で `err` を立てるのと同じです
- **レスポンスは JSON としてパースする。** 空のレスポンスは `null` を返します。`polling` が「更新なし」を `res.body === null` で判定しているためです
- **`search` の再試行は `then` の第2引数で受ける。** `catch` にすると `receive()` が投げた例外まで拾って再検索してしまい、superagent と挙動が変わります
- クエリは `URLSearchParams` で組み立てます。`stripQuery` が空のフィールドを落としたうえで載ります

## polling のエラー処理を直しました

以前は `err` を見ずに `res.body` を触っていました。

```js
.end((err, res) => {
  if (res.body === null) {   // ← err を見ていない
```

superagent は通信そのものが失敗すると `res` を渡さないので `TypeError` になり、**ポーリングがそこで止まっていました**。`search` と同じく間を置いて再試行する形にしました。

## 同条件での A/B が完全に一致しました

実 API はサーバ側の集約タイミングで `running` が変わり、温まっていると初回で完了して polling が0回になります。実測で **997件・polling 0回** と **2件・polling 7回** の両方が出たので、実 API では比較になりません。

そこで Unitrad API をスタブして、検索 → polling（1回目は `null`、2回目で差分）→ 差分適用 → 詳細表示まで通しました。**スタブはホスト名ではなくパスで当てています**（ホスト決め打ちにすると向き先が違うときに実 API へ素通りします）。

superagent 版（#163 の HEAD）と fetch 版で次のすべてが一致しました。

| | superagent 版 | fetch 版 |
|---|---|---|
| search / polling / mapper の回数 | 1 / 2 / 3 | 同じ |
| search の URL | `.../v1/search?free=%E3%81%AD%E3%81%93&region=sabae` | 同じ |
| polling の URL | `.../v1/polling?uuid=stub-uuid&version=1&diff=1&timeout=10` | 同じ |
| 差分適用後の件数 | 3件 | 同じ |
| 書名 | `["いっさつめ","にさつめ","さんさつめ"]` | 同じ |
| ローディング表示 | 消える | 同じ |
| 詳細の書名 / 所蔵 / リンク | `いっさつめ` / `一般書架 [3]` / `https://example.invalid/b1` | 同じ |
| エラー | 0件 | 0件 |

## CORS について（今回の変更とは無関係です）

手元の http オリジンから実 API を叩くと polling が CORS で落ちることがありますが、**fetch 固有ではありません**。切り分けた結果がこれです。

- 同じ URL に **XHR（superagent が内部で使う経路）を投げても `onerror` で同じように落ちる**
- `search` でも起きる（fetch でも XHR でも）
- `curl` で確かめると `/v1/search` も `/v1/polling` も `Access-Control-Allow-Origin: *` を返しているので **API 側の問題でもない**

ロングポーリングの接続が手元の環境で切られているためで、本番の WebView（`file://` や `app://localhost` オリジン）では起きません。

## テスト

`test/api.test.js` を追加しました（20件 → **26件**）。fetch をスタブして次を固定しています。

- 空でないフィールドだけが URL に載る
- 2xx 以外で再試行する
- 通信そのものの失敗でも再試行する
- `kill()` 後は結果を配らない
- `polling` が `null` を「更新なし」として再試行する
- `polling` が通信の失敗で止まらない
- `receive()` が `books_diff` の insert と update を反映する

`test/interop.test.js` から superagent の assertion を外しました（geolib の分は残しています）。

## 見つけた死んだコード（この PR では消していません）

- **`fetchMapping` は参照0件**（unitrad-ui 由来の名残）。さばとマップの棚マッピングは `sabatomap-mapper.calil.jp` を使います
- `normalizeQuery` / `isEmptyQuery` / `isEqualQuery` も app 側からは未使用で、テストが挙動を固定しているだけです

CLAUDE.md に書き残しました。消すかどうかは次の後片付けの PR で判断します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
