### PR TITLE
fix: 起動時にフロアが選択されないのを直す

### DIFF
--- a/src/component/App.jsx
+++ b/src/component/App.jsx
@@ -25,8 +25,24 @@ class Main extends Component {
         // if (this.detailRef.current) {
         //     this.detailRef.current.setState({ query: '' });
         // }
-        this.setState({ floors: [] }); // CSSアニメーション対策のためクリアする
-        this.setState({ systemid: facility.systemid, floors: facility.floors });
+        //
+        // flushSync で1回ずつ流している理由が2つある。
+        //
+        // 1. app.js の loadFacility は、この直後に同期で loadFloor → UI.setFloorId を呼ぶ。
+        //    React 17 までは React のイベント外の setState が同期に流れていたので、
+        //    その時点で Floors がマウント済みだった。createRoot（React 18 以降）の
+        //    自動バッチングでは描画が遅れ、setFloorId が floorsRef.current === null で
+        //    握りつぶされて起動時にどの階も選択されない状態になる。
+        //    InitUI が同じ理由で flushSync しているのと同じ扱いにする。
+        // 2. floors を空にしてから入れ直すのは CSS アニメーションの作り直しが目的で、
+        //    2回の setState が別々に描画されることが前提になっている。
+        //    自動バッチングでまとめられると空の描画が起きず、意図が失われる。
+        flushSync(() => {
+            this.setState({ floors: [] }); // CSSアニメーション対策のためクリアする
+        });
+        flushSync(() => {
+            this.setState({ systemid: facility.systemid, floors: facility.floors });
+        });
     }
     setFloorId(id) {
         if (this.floorsRef.current) {

--- a/test/mount.test.jsx
+++ b/test/mount.test.jsx
@@ -145,4 +145,39 @@ describe('InitUI（本番と同じ入口）', () => {
 
     container.remove();
   });
+
+  /*
+   src/app.js の loadFacility は UI.setFacility(facility) の**直後に同期で**
+   loadFloor(floor.id) → UI.setFloorId(id) を呼ぶ。
+
+   React 17 までは React のイベント外の setState が同期に流れていたので、
+   setFloorId の時点で Floors はマウント済みだった。createRoot（React 18 以降）の
+   自動バッチングでは描画が遅延するため floorsRef.current が null のままで、
+   App.jsx の `if (this.floorsRef.current)` が黙って握りつぶす。
+   結果、起動時にどの階も選択されない。
+
+   act() を挟まずに app.js と同じ順で呼ぶのが再現条件。
+   */
+  it('setFacility の直後に setFloorId を呼んでも階が選択される', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    let instance;
+    await act(async () => {
+      instance = InitUI({ facilities: FACILITIES }, container);
+    });
+
+    await act(async () => {
+      // app.js の loadFacility と同じ並び。間に await を挟まない
+      instance.setFacility(FACILITIES[0]);
+      instance.setFloorId('7');
+    });
+
+    const radios = [...container.querySelectorAll('#floors .floor input')];
+    expect(radios.map((r) => r.value)).toEqual(['8', '7']);   // 階は逆順に並ぶ
+    expect(radios.find((r) => r.value === '7').checked).toBe(true);
+    expect(radios.find((r) => r.value === '8').checked).toBe(false);
+
+    container.remove();
+  });
 });


### PR DESCRIPTION
WEB版を起動して確認していて見つけた不具合です。**ベースは #165**（下に #164 → #163 → #162 → #161 → #160）。

**ビルド構成のモダン化とは無関係の、既存の退行です。** ただし master に入っていて未配信なので、このまま出すと本番に載ります。

## 症状

起動直後、フロアセレクタでどの階も選択されていません。

```
起動直後   8:false 7:false     ← どちらも未選択
```

配信中の https://lab.calil.jp/sabatomap/ では 1F が選択されているので、退行だと分かります。

`app.loadFloor('7')` を後から呼べば選択されます。

```
1. 起動直後                       : 8:false 7:false
2. app.loadFloor('8') を後から呼ぶ : 8:true  7:false
3. app.loadFloor('7') に戻す      : 8:false 7:true
4. 2F のラベルをクリック          : 8:true  7:false
```

つまり `setFloorId` 自体は壊れておらず、**起動時だけ握りつぶされています**。

## 原因

`src/app.js` の `loadFacility` は `UI.setFacility(facility)` の直後に **同期で** `loadFloor(floor.id)` → `UI.setFloorId(id)` を呼びます。

```js
UI.setFacility(facility);            // app.js:119
map.getView().setRotation(...);
map.getView().fit(...);
loadFloor(floor.id);                 // app.js:127 → UI.setFloorId(id)
```

React 17 までは React のイベント外の `setState` が同期に流れていたので、`setFloorId` の時点で `Floors` はマウント済みでした。`createRoot`（React 18 以降）の**自動バッチング**では描画が遅延するため、`this.floorsRef.current` が `null` のままで `App.jsx` の `if (this.floorsRef.current)` が黙って握りつぶします。

壊れた経緯は2段階です。

| commit | 何が起きたか |
|---|---|
| `5e02176`（2025-07-02「React18へ更新」） | string ref を `createRef` に移し、`this.refs.floors.setState(...)` を `if (this.floorsRef.current)` で包んだ。**このときはまだ `ReactDOM.render`（legacy root）だったので同期に流れて動いていた。** ただしガードを足したことで、以後この経路の失敗が例外ではなく無言になった |
| `54743b6`（2026-07-22「ReactとReactDOMのバージョンを19.2.8に更新し、createRootを使用するように変更」） | `createRoot` に移って自動バッチングが有効になり**発症** |

配信中の版は **React 16.13.1 + `ReactDOM.render`** なので影響を受けていません（配信中の `js/all.js` を取得して確認しました）。

## 直し方

`InitUI` が「app.js が戻り値を同期的に使うため」に `flushSync` しているのと同じ扱いを `setFacility` にも与えました。同じファイル内に既にある前例に揃える形です。

**`floors` を空にしてから入れ直している意図も同時に戻ります。** これは CSS アニメーションを作り直すためのもので、2回の `setState` が別々に描画されることが前提になっています。自動バッチングでまとめられると空の描画が起きず、意図が失われていました。修正後はブラウザのコンソールに `Main render called, systemid: undefined` が2回出るようになり、空の描画が復活したことが確認できます。

## 確認したこと

- `test/mount.test.jsx` に再現テストを追加（26件 → **27件**）。`act()` を挟まずに app.js と同じ順で `setFacility` → `setFloorId` を呼ぶのが再現条件です。**修正前は落ち、修正後に通る**ことを確認しました

```
修正前:  × setFacility の直後に setFloorId を呼んでも階が選択される
         AssertionError: expected false to be true
修正後:  Tests  27 passed (27)
```

- 実ブラウザ（Chromium 414x896）で起動直後から `7:checked=true`。フロアセレクタの見た目が配信中の版と一致します
- スタブした Unitrad API で検索 → polling → 差分適用 → 詳細表示まで通り、件数3件・書名・所蔵・リンク・ローディング状態が変わらないこと、エラー0件
- 成果物は +48 バイト（624,673 → 624,721）

## 関連して気づいたこと（この PR では触っていません）

`5e02176` で入った `console.log` が残っています。`InitUI called with element:` / `Main render called, systemid:` / `Rendering Facilities` / `Rendering Search and Floors` / `InitUI instance:` の5箇所で、**描画のたびに本番のコンソールへ出ます**。デバッグの名残なので別途外す判断が要ります。

同じ ref ガードのパターンは `notify` と `setMode`（`locatorRef`）にもあります。こちらは呼ばれるのがマウント後なので現状は問題ありませんが、同種の無言の失敗を招く形ではあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
