### PR TITLE
chore: 本番に残っていたデバッグ用の console.log を外す

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -141,7 +141,6 @@ export class api {
         if (book.detail || !book.holdings.includes(100622)) return;
         // if (fetchCount >= 3) return;
         const url = `https://sabatomap-mapper.calil.jp/get?uuid=${this.data.uuid}&id=${book.id}`
-        console.log(url);
         fetchCount += 1;
         fetch(url).then((r) => r.json()).then((r) => {
           book.detail = r.data;

--- a/src/app.js
+++ b/src/app.js
@@ -63,7 +63,6 @@ let fitRotation = function (r) {
     }
   }
   let view =  map.getView();
-  console.log(virtualAngle,view.rotation);
   if(view.rotation !== virtualAngle){
       view.animate({rotation: virtualAngle * Math.PI / 180, duration: 400, easing: easeOut});
   }
@@ -450,7 +449,6 @@ export default class App {
   }
 
   locatorClicked() {
-    console.log(kanilayer);
     return locatorClicked();
   }
 

--- a/src/component/App.jsx
+++ b/src/component/App.jsx
@@ -60,7 +60,6 @@ class Main extends Component {
         }
     }
     render() {
-        console.log('Main render called, systemid:', this.state.systemid);
         var offline = '';
         if (this.state.offline) {
             offline = (
@@ -68,7 +67,6 @@ class Main extends Component {
             )
         }
         if (this.state.systemid == null) {
-            console.log('Rendering Facilities');
             return (
                 <Fragment>
                     <Facilities facilities={this.props.facilities} />
@@ -76,7 +74,6 @@ class Main extends Component {
                 </Fragment>
             );
         }
-        console.log('Rendering Search and Floors');
         return (
             <Fragment>
                 <Search placeholder="探したいこと・調べたいこと" region={REGION} />
@@ -89,8 +86,6 @@ class Main extends Component {
 }
 
 export default function InitUI(props, element) {
-    console.log('InitUI called with element:', element, 'props:', props);
-
     // app.jsがInitUIの戻り値をコントローラとして同期的に使うため、
     // flushSyncでレンダーを完了させてからMainのインスタンスを返す
     let instance = null;
@@ -98,7 +93,6 @@ export default function InitUI(props, element) {
     flushSync(() => {
         root.render(<Main facilities={props.facilities} ref={(el) => { instance = el; }} />);
     });
-    console.log('InitUI instance:', instance);
     return instance;
 }
 

--- a/src/component/Search.jsx
+++ b/src/component/Search.jsx
@@ -75,7 +75,6 @@ export default class Search extends Component {
         if (this.queryRef.current) {
             this.queryRef.current.blur();
             this.setState({ query: this.queryRef.current.value }, () => {
-                console.log('callback')
                 if (this.state.query != '') {
                 this.startTime = new Date().getTime();
                 if (this.api) this.api.kill();
@@ -93,7 +92,6 @@ export default class Search extends Component {
                         books: data.books,
                         loading: data.running,
                     });
-                    // console.log(data.books)
                     data.books.forEach((book) => {
                         if (this.cacheDetail[book.id]) {
                             book.detail = this.cacheDetail[book.id];
@@ -105,8 +103,6 @@ export default class Search extends Component {
                             book: book,
                         });
                     });
-                    // console.log('this.queueDetail');
-                    // console.log(this.queueDetail);
                 });
                 }
             });


### PR DESCRIPTION
[#166](https://github.com/CALIL/sabatomap/pull/166) で触れた件です。**ベースは #166**（下に #165 → #164 → #163 → #162 → #161 → #160）。

描画やタップのたびにブラウザのコンソールへ出ていたデバッグ出力を取り除きました。大半は `5e02176`（2025-07-02「React18へ更新」）で入ったまま残っていたものです。

## 外したもの（8件）

| 場所 | 出ていたもの | いつ出るか |
|---|---|---|
| `App.jsx` render | `Main render called, systemid:` | **描画のたび** |
| `App.jsx` render | `Rendering Facilities` | 施設未選択の描画のたび |
| `App.jsx` render | `Rendering Search and Floors` | 施設選択後の描画のたび |
| `App.jsx` InitUI | `InitUI called with element:` + props 全体 | 起動時 |
| `App.jsx` InitUI | `InitUI instance:` + インスタンス | 起動時 |
| `app.js` fitRotation | `virtualAngle, view.rotation` | **地図を回すたび** |
| `app.js` locatorClicked | `kanilayer`（レイヤーオブジェクト全体） | 現在地ボタンを押すたび |
| `api.js` getMap | mapper の URL | 書影を取りにいくたび |
| `Search.jsx` onSubmit | `callback` | 検索のたび |

`app.js` の `virtualAngle, view.rotation` は、ol 5 の View に `rotation` という公開プロパティが無いため **常に `undefined` が並んで出ていました**（`177.5 undefined` のような出力）。この件自体は「OpenLayers 5.3.3 を上げる」タスクで扱います。

コメントアウトされたままだった `// console.log(data.books)` と `// console.log('this.queueDetail')` の2箇所も同じデバッグの名残なので消しました。

## 残したもの（4件）

- `api.js` の `[Unitrad] continue...` と `[Unitrad] complete.` — タグ付きで検索の進行を示す意図的なもの
- `api.js` の `fetchMapping` と `app.js` の `startRangingBeaconsInRegion` に渡している `console.error` — 失敗の報告

## 確認したこと

- `npm test` 27件グリーン
- 実ブラウザ（Chromium 414x896）で起動時のコンソールから**アプリ由来の出力が消えた**こと。cordova のプラグインプロキシの出力（`adding proxy for Device` など）だけが残ります
- 起動直後のフロア選択（1F）が維持されていること
- スタブした Unitrad API で検索 → polling → 差分適用 → 詳細表示まで通り、件数3件・書名・所蔵・リンク・ローディング状態が変わらないこと、エラー0件
- 成果物は 624,721 → **624,402 バイト**（-319）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
