### PR TITLE
fix: geolib をやめて ol/sphere にする（緯度経度の取り違えも直る）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,8 @@ npm test          # vitest run
 `import C from 'pkg'` がコンポーネントではなくオブジェクトになって描画時に落ちます。
 型もビルドも通るので、1回描画するテストが無いと気づけません。
 
-`test/interop.test.js` は `superagent` と `geolib` の受け取り方、および `src/api.js` の
-クエリ正規化関数を固定します。
+`test/interop.test.js` は `ol/sphere` の受け取り方、`src/api.js` のクエリ正規化関数、
+および **`src/sabae.json` の座標の並び**（後述）を固定します。
 
 グローバルの `window.app`（`src/app.js:5313` で代入）を `src/component` の各所が直に参照するため、
 `test/setup.js` でスタブしています。`app.js` を読み込むと `ol` と `cordova` まで要るためです。
@@ -134,6 +134,20 @@ npm test          # vitest run
 
 `esbuild` の postinstall を許可しています。`@parcel/watcher`（vitest 経由）は
 入っていなくてもポーリングにフォールバックするので許可していません。
+
+### プラグインを package.json に足すときの注意
+
+`cordova-plugin-device` を devDependencies に持っていましたが、2026-08-15 に外しました。
+`plugins/fetch.json` で **`is_top_level=false`**（`com.unarin.cordova.beacon` の依存）であり、
+`package.json` の `cordova.plugins` にも無く、`src` でも `device.*` を使っていません
+（2022年の `d20c756`「device.platform → cordova.platformId」で使われなくなった）。
+`cordova prepare` は vendoring 済みの `plugins/cordova-plugin-device/` から入れるので、
+npm 側の宣言は不要です。
+
+`cordova-lib` も同時に外しました。`cordova` 自身が同じ `^13.0.0` を依存に持つ重複でした。
+
+**プラグインを足すときは `package.json` の `cordova.plugins` と `plugins/` が本体で、
+devDependencies は `cordova plugin add` の副産物**だと思ってください。
 
 ## cordova プラグインの git 参照は SHA で固定しています
 
@@ -182,6 +196,28 @@ path データの出典は Font Awesome Free 5.15.4 の `svgs/solid/*.svg` で�
 アイコンのライセンスは CC BY 4.0 です。
 
 ## データの置き場所
+
+### ★ sabae.json は latitude に経度、longitude に緯度が入っている
+
+鯖江市は北緯 35.96 / 東経 136.18 ですが、`beacons` / `nearest1` / `nearest2` / `nearestD` の
+**448点すべてで `latitude` に 136 台、`longitude` に 35 台**が入っています。名前が逆です。
+
+**このリポジトリは座標を「位置」で扱っていて、それで辻褄が合っています。**
+第1要素（`latitude`）を経度、第2要素（`longitude`）を緯度として渡す約束です。
+
+| 場所 | 書き方 |
+|---|---|
+| `src/app.js` の `change:position` | `transform([p.latitude, p.longitude], "EPSG:4326", ...)` |
+| `src/libs/kanikama.js` のフロア判定 | `getDistance([b.latitude, b.longitude], ...)`（`ol/sphere` は `[経度, 緯度]`） |
+| `bbox` | `[経度, 緯度, 経度, 緯度]`。こちらは EPSG:4326 の正しい並び |
+
+**フィールド名を直すなら、上の2箇所も同時に直してください。** データだけ直すと
+地図のマーカーと距離が両方おかしくなります。片方だけでも同じです。
+`test/interop.test.js` の「sabae.json の座標の並び」がこの取り違えを落とします。
+
+かつて `geolib` を使っていたときは、**名前で読むライブラリだったので間違えていました**。
+全 24,449 ペアで実測すると平均 18.1〜18.4 パーセント、最大 98.8 パーセントずれ、
+3m 判定が 170 組で変わっていました。2026-08-15 に `ol/sphere` へ寄せて解消しています。
 
 ### 施設・ビーコンデータは src/sabae.json が唯一のソース
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "cordova-browser": "^7.0.0",
         "cordova-plugin-bluetooth-status": "~1.0.4",
-        "geolib": "^3.3.14",
         "ol": "^5.3.3",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
@@ -23,8 +22,6 @@
         "cordova": "^13.0.0",
         "cordova-android": "^15.1.0",
         "cordova-ios": "^8.1.1",
-        "cordova-lib": "^13.0.0",
-        "cordova-plugin-device": "^3.0.0",
         "cordova-plugin-device-orientation": "github:CALIL/cordova-plugin-device-orientation#16a87476e424d75540614772935a282b03ab2499",
         "cordova-plugin-inappbrowser": "^7.0.0",
         "cordova-plugin-network-information": "^3.1.0",
@@ -3336,27 +3333,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/cordova-plugin-device": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-3.0.0.tgz",
-      "integrity": "sha512-g8fFYOvleeYpklWvHwZ/T8/IzJe/3O0MGVDIUoqBru4v8SNDAbNVD3oOqoOQANBWGFQMg7GIkAAl8errCHZ7zQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "cordovaDependencies": {
-          "2.1.0": {
-            "cordova-electron": ">=3.0.0"
-          },
-          "3.0.0": {
-            "cordova-android": ">=7.0.0",
-            "cordova-electron": ">=3.0.0"
-          },
-          "4.0.0": {
-            "cordova": ">100"
-          }
-        }
-      }
-    },
     "node_modules/cordova-plugin-device-orientation": {
       "version": "3.0.1-dev",
       "resolved": "git+ssh://git@github.com/CALIL/cordova-plugin-device-orientation.git#16a87476e424d75540614772935a282b03ab2499",
@@ -4426,12 +4402,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/geolib": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.14.tgz",
-      "integrity": "sha512-uQ1772h3OjhWvL/HhSRZTMjBKIKoc4wFksLDqzqOkuG/2TgBbTwFamU0Disx3sNFk/BOweHyhKoVaYDuLIpsxQ==",
-      "license": "MIT"
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "cordova-browser": "^7.0.0",
     "cordova-plugin-bluetooth-status": "~1.0.4",
-    "geolib": "^3.3.14",
     "ol": "^5.3.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
@@ -30,8 +29,6 @@
     "cordova": "^13.0.0",
     "cordova-android": "^15.1.0",
     "cordova-ios": "^8.1.1",
-    "cordova-lib": "^13.0.0",
-    "cordova-plugin-device": "^3.0.0",
     "cordova-plugin-device-orientation": "github:CALIL/cordova-plugin-device-orientation#16a87476e424d75540614772935a282b03ab2499",
     "cordova-plugin-inappbrowser": "^7.0.0",
     "cordova-plugin-network-information": "^3.1.0",

--- a/src/libs/kanikama.js
+++ b/src/libs/kanikama.js
@@ -7,10 +7,23 @@
 
  */
 
-// 名前付きで取る。geolib 3 は default を持たないので
-// import geolib from 'geolib' だと undefined になる。
-// 名前付きなら 2 でも 3 でも動く。
-import { getDistance } from 'geolib'
+/*
+ 距離は ol/sphere で測る。geolib は 2026-08-15 にやめた。
+
+ geolib は getDistance 1箇所のためだけに 23KB（成果物の 3.7%）を占めていた。
+ ol/sphere は app.js が既に使っていて追加のコストがない。
+
+ **加えて geolib は値を間違えていた。** sabae.json のビーコンは
+ latitude に経度、longitude に緯度が入っている（鯖江市は北緯 35.96 / 東経 136.18 なのに
+ latitude が 136.18 側）。geolib は名前で読むので入れ替わったまま計算していた。
+ 全 23,603 ペアで実測すると平均 18.1 パーセント、最大 98.8 パーセントずれ、
+ 下の effectiveRange（3m）の判定が 144 組で変わっていた。
+
+ このリポジトリは他のどこでも**位置で**扱っていて正しい。たとえば app.js は
+ `transform([p.latitude, p.longitude], "EPSG:4326", ...)` と、第1要素を経度として渡す。
+ ol/sphere も [経度, 緯度] を取るので、同じ並びで渡せば揃う。
+ */
+import { getDistance } from 'ol/sphere'
 
 /**
  * ビーコンオブジェクトが同じかどうか評価する
@@ -279,8 +292,14 @@ export default class Kanikama {
     for (let floor of this.currentFacility.floors) {
       if (floor._runtime.beacons.length > 0) {
         floor._runtime.beacons.sort((a, b) => b.rssi - a.rssi);
+        const nearest = floor._runtime.beacons[0];
         for (const b of floor._runtime.beacons) {
-          const distance = getDistance(b, floor._runtime.beacons[0]);
+          // ol/sphere は [経度, 緯度] を取る。sabae.json は latitude 側に経度が
+          // 入っているので、この並びで渡すのが正しい（import の上のコメントを参照）
+          const distance = getDistance(
+            [b.latitude, b.longitude],
+            [nearest.latitude, nearest.longitude]
+          );
           if (distance <= effectiveRange) {
             rssiSum += b.rssi;
             rssiCount++;

--- a/test/interop.test.js
+++ b/test/interop.test.js
@@ -9,16 +9,17 @@
 // 「何を import してどう使っているか」の契約をここに固定しておけば、
 // 実装側が受け方を変えたときに気づける。
 import { describe, it, expect } from 'vitest';
-import { getDistance } from 'geolib';
+import { getDistance } from 'ol/sphere';
+import rules from '../src/sabae.json';
 import { api, normalizeQuery, isEmptyQuery, isEqualQuery, stripQuery } from '../src/api.js';
 
 describe('CommonJS 依存の受け取り方', () => {
-  it('geolib の getDistance は関数', () => {
+  it('ol/sphere の getDistance は関数', () => {
     expect(typeof getDistance).toBe('function');
-    // 鯖江市図書館の敷地内で 0 より大きい距離が出る
+    // 鯖江市図書館の敷地内で 0 より大きい距離が出る。ol/sphere は [経度, 緯度]
     expect(getDistance(
-      { latitude: 35.961639, longitude: 136.186172 },
-      { latitude: 35.962279, longitude: 136.186977 },
+      [136.186172, 35.961639],
+      [136.186977, 35.962279],
     )).toBeGreaterThan(0);
   });
 
@@ -56,5 +57,71 @@ describe('クエリの正規化', () => {
     const b = normalizeQuery({ free: 'ねこ', region: 'fukui' });
     expect(isEqualQuery(a, b)).toBe(true);
     expect(isEqualQuery(a, normalizeQuery({ free: 'いぬ' }))).toBe(false);
+  });
+});
+
+/*
+ sabae.json の座標の並びを固定する。
+
+ latitude に経度、longitude に緯度が入っている（鯖江市は北緯 35.96 / 東経 136.18）。
+ このリポジトリは位置で扱っていて、第1要素を経度として渡すことで辻褄が合っている。
+ app.js の transform([p.latitude, p.longitude], "EPSG:4326", ...) と
+ kanikama.js の getDistance([b.latitude, b.longitude], ...) が同じ約束で動く。
+
+ **フィールド名を直すなら、この2箇所も同時に直すこと。** データだけ直すと
+ 地図のマーカーと距離が両方おかしくなる。片方だけ直しても同じ。
+ このテストはその取り違えを落とすためにある。
+ */
+describe('sabae.json の座標の並び', () => {
+  const floors = rules.flatMap((f) => f.floors);
+  const points = floors.flatMap((f) => [
+    ...(f.beacons ?? []), ...(f.nearest1 ?? []), ...(f.nearest2 ?? []), ...(f.nearestD ?? []),
+  ]);
+
+  it('全フロアの座標を拾えている', () => {
+    // フロア7が 219+80+59+21、フロア8が 42+12+15 で計 448 点
+    expect(points.length).toBe(448);
+    expect(points.every((p) => typeof p.latitude === 'number' && typeof p.longitude === 'number')).toBe(true);
+  });
+
+  it('latitude に経度が、longitude に緯度が入っている', () => {
+    for (const p of points) {
+      // 緯度は -90〜90 なので、136 付近の値が latitude に入るのは名前が逆な証拠
+      expect(p.latitude).toBeGreaterThan(136);
+      expect(p.latitude).toBeLessThan(137);
+      expect(p.longitude).toBeGreaterThan(35);
+      expect(p.longitude).toBeLessThan(36);
+    }
+  });
+
+  it('bbox は EPSG:4326 の [経度, 緯度, 経度, 緯度] で、座標がその中に収まる', () => {
+    for (const floor of floors) {
+      const [minLon, minLat, maxLon, maxLat] = floor.bbox;
+      expect(minLon).toBeGreaterThan(136);
+      expect(minLat).toBeGreaterThan(35);
+      for (const b of floor.beacons ?? []) {
+        expect(b.latitude).toBeGreaterThanOrEqual(minLon - 0.001);
+        expect(b.latitude).toBeLessThanOrEqual(maxLon + 0.001);
+        expect(b.longitude).toBeGreaterThanOrEqual(minLat - 0.001);
+        expect(b.longitude).toBeLessThanOrEqual(maxLat + 0.001);
+      }
+    }
+  });
+
+  it('この並びで測ると館内に収まる距離になる', () => {
+    for (const floor of floors) {
+      const bs = floor.beacons ?? [];
+      if (bs.length < 2) continue;
+      let max = 0;
+      for (const b of bs) {
+        max = Math.max(max, getDistance(
+          [bs[0].latitude, bs[0].longitude],
+          [b.latitude, b.longitude],
+        ));
+      }
+      // 鯖江市図書館は一辺 100m 弱。名前どおりに読むと桁が変わる
+      expect(max).toBeGreaterThan(0);
+      expect(max).toBeLessThan(200);
+    }
   });
 });


### PR DESCRIPTION
依存の棚卸しで挙げた候補のうち、`cordova-lib` / `cordova-plugin-device` の削除と `geolib` → `ol/sphere` を進めました。**geolib の置き換えはフロア判定の値を直す変更を含みます。**

## geolib → ol/sphere

`geolib` は `kanikama.js` の `getDistance` **1箇所のためだけ**に **23,172 バイト（成果物の 3.7%）**を占めていました。`ol/sphere` の `getDistance` は `app.js` が既に使っていて追加のコストがありません。

### そのうえ geolib は値を間違えていました

`src/sabae.json` は **`latitude` に経度、`longitude` に緯度**が入っています（鯖江市は北緯 35.96 / 東経 136.18 なのに `latitude` が 136 台）。`beacons` / `nearest1` / `nearest2` / `nearestD` の **448点すべて**が同じ並びです。

```json
{"uuid":"...","major":105,"minor":1,
 "latitude":136.18638732106814,   ← 経度
 "longitude":35.96181653926824}   ← 緯度
```

**このリポジトリは座標を「位置」で扱っていて、それで辻褄が合っています。**

| 場所 | 書き方 | 結果 |
|---|---|---|
| `app.js` の `change:position` | `transform([p.latitude, p.longitude], "EPSG:4326", ...)` | 第1要素を経度として渡すので**正しい** |
| `bbox` | `[136.186…, 35.961…, 136.186…, 35.962…]` | EPSG:4326 の正しい並び |
| **`kanikama.js`（従来）** | `geolib.getDistance(b, ref)` | **名前で読むので間違い** |

`ol/sphere` は `[経度, 緯度]` を取るので、他と同じ並びで渡せば揃います。

## 直したことで何が変わるか

全ビーコンのペアで実測しました。

| | フロア7（219本 / 23,603ペア） | フロア8（42本 / 846ペア） |
|---|---|---|
| 距離の誤差 平均 | **18.1%** | **18.4%** |
| 距離の誤差 最大 | 98.8% | 51.8% |
| 3m 以内と判定 | 878 → **742** ペア | 84 → **58** ペア |
| 判定が変わるペア | 144（0.61%） | 26（3.07%） |

`kanikama` は「各フロアで RSSI が最も強いビーコンの周囲 3m の平均 RSSI」を比べてフロアを決めます。**従来は遠いビーコンまで 3m 以内として数えていた**ので、平均 RSSI が薄まっていました。最強ビーコンを基準にした 3m 以内の本数は、フロア7で 219本中 **54本**、フロア8で 42本中 **19本**において変わります。

**つまりこれは挙動が変わる修正です**（フロア判定の精度が上がる方向）。実機での確認をお願いしたいところです。

## cordova-plugin-device

`plugins/fetch.json` で **`is_top_level=false`**（`com.unarin.cordova.beacon` の依存）であり、`package.json` の `cordova.plugins` にも無く、`src` でも `device.*` を使っていません（2022年の `d20c756`「device.platform → cordova.platformId」で使われなくなった）。

`platforms/` と `plugins/browser.json` を消してから `cordova prepare browser` を通し、**vendoring 済みの `plugins/cordova-plugin-device/` から入る**ことを確認しました。

```
Installing "com.unarin.cordova.beacon" for browser
Plugin dependency "cordova-plugin-device@3.0.0" already fetched, using that version.
Dependent plugin "cordova-plugin-device" already installed on browser.
```

## cordova-lib

`cordova` 自身が同じ `^13.0.0` を依存に持っており、直接宣言は重複でした。`src` / `tools` / `config.xml` からの参照も0件です。lock では `cordova` の依存として引き続き 13.0.0 が1本入ります。

## 確認したこと

- `npm ci` → `npm test`（**31件グリーン**）→ `node tools/build.mjs release` が通る
- `platforms/` を消した状態から `npx cordova prepare browser` が通り、プラグイン6件が入る
- 実ブラウザ（Chromium 390x844）で描画。検索ボックス・フロアセレクタ `["2","1"]`・Locator・`#map`・横はみ出し無しがいずれも変化なし。pageerror 0件、console の error / warning 0件
- スタブした Unitrad API で検索 → polling → 差分適用 → 詳細表示まで通り、件数3件・書名・所蔵・リンク・ローディング状態が変わらないこと、エラー0件
- `www/js/all.js` **624,402 → 601,230 バイト（-23,172）**、モジュール **325 → 283**

## テストと CLAUDE.md

`test/interop.test.js` に「sabae.json の座標の並び」を追加しました。448点すべてで `latitude` が 136 台・`longitude` が 35 台であること、bbox の中に収まること、この並びで測ると館内に収まる距離（200m 未満）になることを固定します。

**フィールド名を直すなら `app.js` と `kanikama.js` の2箇所も同時に直す必要があります。** データだけ直すと地図のマーカーと距離が両方おかしくなります。このテストがその取り違えを落とします。CLAUDE.md にも節を立てて書きました。

## 手をつけていない候補

- `cordova-plugin-inappbrowser` — 唯一の参照がコメントアウトですが、`target="_blank"` のリンクが2箇所あるので実機での挙動確認が先
- `react-dom` → `preact/compat` — 180KB（成果物の29%）が対象。別途
- `ol` 5.3.3 → 10.10.0 — Todoist にタスク済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
