### PR TITLE
perf: 起動時間を短縮する（Android のスプラッシュ 7秒→2秒ほか）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,49 @@ UTF-8 を出していて本番で動いていたので挙動を合わせまし�
 **`// @flow` を書き戻さないでください。** rolldown / oxc / esbuild はいずれも Flow を扱えず、
 プラグマ1行だけで `Flow is not supported` としてパースを拒否します。`vitest` が動かなくなります。
 
+## React は preact/compat に差し替えています
+
+ソースは `import React from 'react'` のまま書けますが、**成果物に入るのは preact** です。
+`tools/build.mjs` の esbuild `alias` で差し替えています。react-dom が成果物の 28%
+（180KB）を占めていたためで、628KB → 462KB になりました。
+
+**`vitest.config.mjs` にも同じ alias を入れてあります。** 揃えないとテストは react を、
+実機は preact を動かすことになり、マウントテストが本番と別物を検証してしまいます。
+
+`act` だけは経路が違います。react は本体（`'react'`）から出しますが、preact/compat は
+出さず **`preact/test-utils`** にあります。`test/mount.test.jsx` はそちらから取っています。
+
+差し替えても **e2e の基準画像は 8 枚とも 1 画素も変わりませんでした。**
+
+## スプラッシュはアプリ側が消しています
+
+**最短 2 秒出したうえで、地図が描き終わるのを待って消します**（`app.js` の `hideSplash`）。
+通信が死んでいても 8 秒で打ち切ります。
+
+`config.xml` の `AutoHideSplashScreen=false` と対で動きます。**true のままだと
+cordova-android は `navigator.splashscreen.hide()` を受け付けません**
+（`SplashScreenPlugin.java` の `action.equals("hide") && autoHide == false`）。
+
+**`SplashScreenDelay` は書かないでください。** 指定すると cordova-android は
+`onPageFinished` を見なくなり、その時間だけ出しっぱなしになります。2026-08-15 まで
+`7000` が入っていて、アプリの準備が 0.5 秒で終わっても **7 秒**待たされていました。
+
+`cordova-plugin-splashscreen` は入っていませんが、**cordova-android 15 と cordova-ios 8 は
+スプラッシュをプラットフォーム本体で持っている**ので、これらの preference は生きています。
+
+ブラウザ版は `www/index.html` の `#splash` が担当します（cordova-browser に実装が無いため）。
+`app.css` より先に出したいのでスタイルはインラインです。**全画面を覆うので、e2e は
+`#splash` が消えるのを待ってから撮ります。**
+
+### 起動時間の測り方
+
+```bash
+node test/e2e/startup.mjs 7
+```
+
+ネットワークは e2e と同じスタブなので、JS の解析・実行とアプリ側の待ち時間だけを
+切り出せます。デスクトップでの絶対値に意味は無いので、**変更の前後を同じ機械で**比べます。
+
 ## テスト
 
 ```bash

--- a/config.xml
+++ b/config.xml
@@ -14,8 +14,17 @@
     <preference name="DisallowOverscroll" value="true" />
     <preference name="Orientation" value="default" />
     <preference name="webviewbounce" value="false" />
-    <preference name="ShowSplashScreenSpinner" value="false" />
-    <preference name="SplashScreenDelay" value="7000" />
+    <!-- スプラッシュはアプリ側が消す（app.js の hideSplash）。
+         最短 2 秒出したうえで、地図が描き終わるのを待って消す。
+
+         false にしないと cordova-android は navigator.splashscreen.hide() を
+         受け付けない（SplashScreenPlugin.java の `action.equals("hide") &&
+         autoHide == false`）。既定は true。
+
+         SplashScreenDelay は指定しない。指定すると android は onPageFinished を
+         見なくなり、その時間だけ出しっぱなしになる。以前は 7000 が入っていて、
+         アプリの準備が 0.5 秒で終わっても 7 秒待たされていた -->
+    <preference name="AutoHideSplashScreen" value="false" />
     <platform name="android">
         <!-- 下限。書かないと cordova-android の既定（15 では 24 = Android 7.0）が
              黙って効くので明示する。
@@ -27,7 +36,6 @@
              インストールできる端末を狭めるものではない -->
         <preference name="android-targetSdkVersion" value="36" />
         <allow-intent href="market:*" />
-        <preference name="SplashShowOnlyFirstTime" value="true" />
         <icon density="mdpi" src="res/icons/android/icon-48-mdpi.png" />
         <icon density="hdpi" src="res/icons/android/icon-72-hdpi.png" />
         <icon density="xhdpi" src="res/icons/android/icon-96-xhdpi.png" />
@@ -53,8 +61,6 @@
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <preference name="FadeSplashScreen" value="true" />
-        <preference name="ShowSplashScreenSpinner" value="false" />
-        <preference name="AutoHideSplashScreen" value="false" />
         <preference name="Orientation" value="all" />
         <icon height="57" platform="ios" src="res/icons/ios/icon.png" width="57" />
         <icon height="114" platform="ios" src="res/icons/ios/icon@2x.png" width="114" />
@@ -87,11 +93,7 @@
         <preference name="WindowsDefaultUriPrefix" value="ms-appx://" />
     </platform>
     <platform name="browser">
-        <preference name="SplashScreen" value="img/splash_for_browser.png" />
-        <preference name="SplashScreenDelay" value="3000" />
-        <preference name="SplashScreenBackgroundColor" value="#0068B1" />
-        <preference name="ShowSplashScreen" value="true" />
-        <preference name="SplashScreenWidth" value="428" />
-        <preference name="SplashScreenHeight" value="154" />
+        <!-- cordova-browser にスプラッシュの実装は無く、以下は 1 つも読まれていなかった。
+             ブラウザ版のスプラッシュは www/index.html の #splash が担当する -->
     </platform>
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "ol": "10.10.0",
+        "preact": "10.29.8",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       },
@@ -7007,6 +7008,24 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
     },
     "node_modules/proc-log": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "ol": "10.10.0",
+    "preact": "10.29.8",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -153,7 +153,10 @@ var loadFloor = function (id) {
     }
 
     kanimarker.setPosition(null);
-    kanilayer.setFloorId(id);
+    // 起動直後だけフェードを飛ばす。クロスフェードは「前のフロアから次のフロアへ」の
+    // 演出で、初回は退避先の tileB に入るのが tileA の source＝null。
+    // 相手がいないのに 378ms 動いていた（フェーズ0のタイル待ち → 200ms → 150ms）
+    kanilayer.setFloorId(id, kanilayer.floorId !== false);
     UI.setFloorId(id);
   }
 

--- a/src/app.js
+++ b/src/app.js
@@ -334,9 +334,14 @@ var initializeApp = function () {
     })
   });
 
-  setTimeout((function () {
+  // ベースタイル（建物の外の地図）は最初は隠しておく。起動直後のビューは
+  // 日本全体（zoom 6）で、施設へ寄せる前にこれを出すと日本地図が一瞬見えるため。
+  //
+  // 以前は 500ms の固定待ちだったが、実測ではビューが施設へ寄るのは 100ms 前後で、
+  // 400ms ぶん無駄に待っていた。配架図が描き終わってから出す
+  map.once("rendercomplete", function () {
     return osm.setVisible(true);
-  }), 500);
+  });
 
   kanimarker = new Kanimarker(map);
   kanimarker.on("change:mode", invalidateLocator);

--- a/src/app.js
+++ b/src/app.js
@@ -164,6 +164,64 @@ var didRangeBeaconsInRegion = function (beacons) {
   return kanikama.push(beacons);
 };
 
+// スプラッシュを出しておく最短時間（ミリ秒）。ロゴを見せるための下限で、
+// アプリの準備はこれより早く終わる（実測で地図が描き終わるのが 0.5 秒前後）
+var SPLASH_MIN = 2000;
+
+// 地図が出ないときの打ち切り。通信が死んでいても必ず消えるようにする
+var SPLASH_MAX = 8000;
+
+var splashHidden = false;
+
+/**
+ * スプラッシュを消す
+ *
+ * index.html の #splash（ブラウザ版の本体）と、cordova のネイティブスプラッシュを
+ * 同時に消す。実機ではネイティブが上に被さっているので #splash は見えない。
+ *
+ * ネイティブ側は config.xml の AutoHideSplashScreen=false と対で動く。
+ * true のままだと cordova-android は hide を受け付けず、SplashScreenDelay の
+ * 時間だけ出しっぱなしになる
+ */
+var hideSplash = function () {
+  if (splashHidden) {
+    return;
+  }
+  splashHidden = true;
+
+  var el = document.getElementById("splash");
+  if (el != null) {
+    el.classList.add("hidden");
+    setTimeout(function () {
+      if (el.parentNode != null) {
+        el.parentNode.removeChild(el);
+      }
+    }, 300);
+  }
+
+  if (navigator.splashscreen != null) {
+    navigator.splashscreen.hide();
+  }
+};
+
+/**
+ * 地図が描き終わってからスプラッシュを消す。ただし最短 SPLASH_MIN は待つ
+ */
+var scheduleHideSplash = function () {
+  setTimeout(hideSplash, SPLASH_MAX);
+
+  var done = function () {
+    var rest = SPLASH_MIN - performance.now();
+    setTimeout(hideSplash, rest > 0 ? rest : 0);
+  };
+
+  if (map != null) {
+    map.once("rendercomplete", done);
+  } else {
+    done();
+  }
+};
+
 var initializeApp = function () {
   var region;
   var delegate;
@@ -232,10 +290,6 @@ var initializeApp = function () {
       locationManager.setDelegate(delegate);
       region = new locationManager.BeaconRegion("sabatomap", "00000000-71C7-1001-B000-001C4D532518");
       locationManager.startRangingBeaconsInRegion(region).fail(console.error);
-    }
-
-    if (navigator.splashscreen != null) {
-      setTimeout(navigator.splashscreen.hide, 2000);
     }
 
     if (navigator.connection != null && navigator.connection.type === "none") {
@@ -350,6 +404,11 @@ var initializeApp = function () {
   window.addEventListener("BluetoothStatus.enabled", invalidateLocator);
   window.addEventListener("BluetoothStatus.disabled", invalidateLocator);
   kanikama.facilities_ = rules;
+
+  // プラットフォームを問わず走らせる。上の cordova ブロックは
+  // platformId !== "browser" で括られていて、ブラウザ版はそこを通らない
+  scheduleHideSplash();
+
   return loadFacility("7");
 };
 

--- a/test/e2e/startup.mjs
+++ b/test/e2e/startup.mjs
@@ -38,11 +38,16 @@ for (let i = 0; i < RUNS; i++) {
     document.addEventListener('deviceready', () => mark('deviceready'), false);
 
     // 実機のスプラッシュはアプリが hide を呼ぶまで出る。
-    // ブラウザには実装が無いので、呼ばれた時刻だけ記録する
-    navigator.splashscreen = {
-      hide: () => mark('splashHidden'),
-      show: () => {},
-    };
+    // ブラウザには実装が無いので、呼ばれた時刻だけ記録する。
+    // cordova.js の modulemapper が後から上書きしにいくので、
+    // 代入ではなく再定義できないアクセサとして置く
+    const stub = {hide: () => mark('splashHidden'), show: () => {}};
+    Object.defineProperty(navigator, 'splashscreen', {
+      configurable: false,
+      enumerable: true,
+      get: () => stub,
+      set: () => {},
+    });
 
     // window.app が生えた瞬間と initializeApp が呼ばれた瞬間
     let app;
@@ -86,6 +91,10 @@ for (let i = 0; i < RUNS; i++) {
     m.once('rendercomplete', () => { window.__mark('settled'); res(); });
     m.render();
   }));
+  // スプラッシュを消す時刻は地図より後になりうるので最後に待つ。
+  // 呼ばれないビルドもあるので取りこぼしても止めない
+  await page.waitForFunction(() => window.__t.splashHidden !== undefined, null, {timeout: 9000})
+    .catch(() => {});
 
   const t = await page.evaluate(() => {
     const nav = performance.getEntriesByType('navigation')[0];

--- a/test/e2e/startup.mjs
+++ b/test/e2e/startup.mjs
@@ -1,0 +1,162 @@
+/*
+ 起動の内訳を測る。テストからは使わない。
+
+   node startup.mjs [回数]
+
+ ネットワークは e2e と同じスタブなので通信の揺らぎが入らず、JS の解析・実行と
+ アプリ側の待ち時間だけを切り出せる。デスクトップでの絶対値に意味は無いので、
+ 変更の前後を同じ機械で比べること。
+
+ スプラッシュは cordova-browser が実装を持たないのでここでは測れない。
+ 代わりに「アプリが hide を呼ぶ時点」（splashHidden）を印にしてある。
+ 実機のスプラッシュはこの時刻まで出ることになる。
+*/
+import {chromium} from '@playwright/test';
+import {createServer, PORT} from './support/server.mjs';
+import {stubNetwork} from './support/stub.mjs';
+
+const RUNS = Number(process.argv[2] ?? 5);
+const server = createServer();
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const browser = await chromium.launch();
+const rows = [];
+
+for (let i = 0; i < RUNS; i++) {
+  const ctx = await browser.newContext({
+    viewport: {width: 414, height: 896},
+    deviceScaleFactor: 2,
+  });
+  const page = await ctx.newPage();
+  await stubNetwork(page, {port: PORT});
+
+  // アプリのコードより先に入れて、節目に印を打つ
+  await page.addInitScript(() => {
+    window.__t = {};
+    const mark = (k) => { if (window.__t[k] === undefined) window.__t[k] = performance.now(); };
+    window.__mark = mark;
+    document.addEventListener('deviceready', () => mark('deviceready'), false);
+
+    // 実機のスプラッシュはアプリが hide を呼ぶまで出る。
+    // ブラウザには実装が無いので、呼ばれた時刻だけ記録する
+    navigator.splashscreen = {
+      hide: () => mark('splashHidden'),
+      show: () => {},
+    };
+
+    // window.app が生えた瞬間と initializeApp が呼ばれた瞬間
+    let app;
+    Object.defineProperty(window, 'app', {
+      configurable: true,
+      get: () => app,
+      set: (v) => {
+        mark('appReady');            // all.js の実行が終わった
+        app = v;
+        const orig = v.initializeApp.bind(v);
+        v.initializeApp = function () { mark('initStart'); const r = orig(); mark('initEnd'); return r; };
+      },
+    });
+
+    // 節目を rAF で拾う
+    const poll = () => {
+      if (document.querySelector('#ui input[type=search]')) mark('uiMounted');
+      if (document.querySelector('#floors input:checked')) mark('floorChosen');
+      const m = window.app && window.app.getMap && window.app.getMap();
+      if (m) {
+        if (window.__t.mapCreated === undefined) {
+          mark('mapCreated');
+          // 地図が初めて描き終わった瞬間。ベースタイルの 500ms とは独立に測る
+          m.once('rendercomplete', () => mark('mapFirstRender'));
+        }
+        if (m.getLayers().item(0).getVisible()) mark('baseVisible');
+      }
+      requestAnimationFrame(poll);
+    };
+    requestAnimationFrame(poll);
+  });
+
+  await page.goto(`http://127.0.0.1:${PORT}/`, {waitUntil: 'commit'});
+  await page.waitForFunction(
+    () => window.__t && window.__t.baseVisible && window.__t.mapFirstRender,
+    null, {timeout: 20000}
+  );
+  // ベースタイルまで含めて落ち着くまで
+  await page.evaluate(() => new Promise((res) => {
+    const m = window.app.getMap();
+    m.once('rendercomplete', () => { window.__mark('settled'); res(); });
+    m.render();
+  }));
+
+  const t = await page.evaluate(() => {
+    const nav = performance.getEntriesByType('navigation')[0];
+    const res = performance.getEntriesByType('resource');
+    const js = res.find((r) => /all\.js$/.test(r.name));
+
+    // 種類ごとに「何本・いつ始まり・いつ終わったか」
+    const group = (re) => {
+      const es = res.filter((r) => re.test(r.name));
+      if (!es.length) return null;
+      return {
+        n: es.length,
+        first: +Math.min(...es.map((e) => e.startTime)).toFixed(1),
+        last: +Math.max(...es.map((e) => e.responseEnd)).toFixed(1),
+      };
+    };
+    const groups = {
+      geojson: group(/calil\.sabatomap2\/\d+\.json/),
+      floorTile: group(/sabatomap\/tiles\//),
+      baseTile: group(/api\.mapbox\.com/),
+    };
+    const paint = performance.getEntriesByType('paint')
+      .reduce((a, p) => (a[p.name] = p.startTime, a), {});
+    return {
+      ...window.__t,
+      jsStart: js.startTime,
+      jsEnd: js.responseEnd,
+      jsSize: js.decodedBodySize,
+      fcp: paint['first-contentful-paint'] ?? 0,
+      dcl: nav.domContentLoadedEventEnd,
+      requests: res.length,
+      groups,
+    };
+  });
+  rows.push(t);
+  await ctx.close();
+}
+
+await browser.close();
+server.close();
+
+const med = (k) => {
+  const s = rows.map((r) => r[k]).filter((v) => typeof v === 'number').sort((a, b) => a - b);
+  return s.length ? +s[Math.floor(s.length / 2)].toFixed(1) : NaN;
+};
+
+const line = (label, k, note = '') =>
+  console.log(`  ${String(med(k)).padStart(7)}  ${label}${note ? '   ' + note : ''}`);
+
+console.log(`${RUNS} 回の中央値（ミリ秒・ナビゲーション開始から）  成果物 ${(rows[0].jsSize / 1024).toFixed(0)} KB\n`);
+line('all.js の取得完了', 'jsEnd');
+line('all.js の実行完了（window.app が生える）', 'appReady', '← ここまでが解析と実行');
+line('first-contentful-paint', 'fcp');
+line('deviceready', 'deviceready');
+line('initializeApp 開始', 'initStart');
+line('initializeApp 終了', 'initEnd');
+line('Map ができた', 'mapCreated');
+line('UI がマウントされた', 'uiMounted');
+line('フロアが決まった', 'floorChosen');
+line('地図が初めて描き終わった', 'mapFirstRender', '← 利用者に配架図が見える');
+line('スプラッシュを消した', 'splashHidden', '← 実機ではここまで出続ける');
+line('ベースタイルが可視化', 'baseVisible');
+line('全部落ち着いた', 'settled');
+console.log(`\n  通信本数 ${med('requests')}`);
+console.log('\n通信の内訳（中央値）');
+for (const k of ['geojson', 'floorTile', 'baseTile']) {
+  const gs = rows.map((r) => r.groups[k]).filter(Boolean);
+  if (!gs.length) { console.log(`  ${k}: 0 本`); continue; }
+  const m = (f) => {
+    const s = gs.map(f).sort((a, b) => a - b);
+    return +s[Math.floor(s.length / 2)].toFixed(1);
+  };
+  console.log(`  ${k.padEnd(10)} ${String(m((g) => g.n)).padStart(3)} 本   ${String(m((g) => g.first)).padStart(7)} → ${String(m((g) => g.last)).padStart(7)} ms`);
+}

--- a/test/e2e/support/app.mjs
+++ b/test/e2e/support/app.mjs
@@ -41,6 +41,9 @@ export async function openApp(page, port) {
     const map = window.app.getMap();
     return map && map.getLayers().item(0).getVisible();
   }, null, { timeout: 20000 });
+  // スプラッシュ（www/index.html の #splash）は最短 2 秒出る。
+  // 全画面を覆うので、消えるまで待たないと地図の代わりにこれを撮ってしまう
+  await page.waitForSelector('#splash', { state: 'detached', timeout: 20000 });
   await settle(page);
   return { net, errors };
 }

--- a/test/mount.test.jsx
+++ b/test/mount.test.jsx
@@ -6,7 +6,11 @@
 // なくオブジェクトになり、描画時に Element type is invalid で落ちる。
 // 型もビルドも通るので、1回描画するテストが無いと気づけない。
 import { describe, it, expect, afterEach } from 'vitest';
-import { act } from 'react';
+// act だけは preact から直接取る。react は本体（'react'）から出すが、
+// preact/compat は出さず preact/test-utils にある。
+// react / react-dom / react-dom/client は vitest.config.mjs の alias で
+// preact/compat に差し替わるので、本番と同じものを動かしている
+import { act } from 'preact/test-utils';
 import { createRoot } from 'react-dom/client';
 
 import InitUI from '../src/component/App.jsx';

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -116,6 +116,22 @@ function jsOptions({ production }) {
        */
       define: { 'process.env.NODE_ENV': JSON.stringify(production ? 'production' : 'development') },
       /*
+       react / react-dom を preact/compat に差し替える。ソースは react のまま書ける。
+
+       react-dom が成果物の 28%（180KB）を占めていた。preact に替えると
+       628KB が 448KB になる。解析と実行が短くなるぶん起動が速い。
+
+       react-dom/client は preact/compat/client に対応が要る（createRoot がある）。
+       react/jsx-runtime は今は使っていないが、将来 automatic runtime に
+       切り替えたときに素の react を掴まないよう先に張っておく。
+       */
+      alias: {
+        react: 'preact/compat',
+        'react-dom': 'preact/compat',
+        'react-dom/client': 'preact/compat/client',
+        'react/jsx-runtime': 'preact/compat/jsx-runtime',
+      },
+      /*
        esbuild の既定は charset: 'ascii' で、日本語を \uXXXX に展開する。
        browserify は生の UTF-8 を出していて本番で動いているので挙動を合わせる。
        www/index.html が <meta charset="utf-8"> を宣言しており、

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -3,6 +3,17 @@ import { defineConfig } from 'vitest/config';
 // このリポジトリに vite.config は無い。vitest は vite.config があるとその root を
 // 引き継ぐので、専用の設定をここに独立して置いている。
 export default defineConfig({
+  // 本番の成果物は tools/build.mjs の alias で preact/compat に差し替わる。
+  // ここを揃えないと、テストは react を、実機は preact を動かすことになり、
+  // マウントテストが本番と別物を検証してしまう
+  resolve: {
+    alias: {
+      react: 'preact/compat',
+      'react-dom/client': 'preact/compat/client',
+      'react-dom': 'preact/compat',
+      'react/jsx-runtime': 'preact/compat/jsx-runtime',
+    },
+  },
   test: {
     environment: 'jsdom',
     include: ['test/**/*.test.{js,jsx}'],

--- a/www/index.html
+++ b/www/index.html
@@ -11,6 +11,29 @@
   <link href="css/app.css" rel="stylesheet" type="text/css">
 </head>
 <body>
+<!--
+  スプラッシュ。app.css より先に出したいので、ここだけインラインで書く。
+
+  実機は cordova のネイティブスプラッシュがこの上に被さっているので普段は見えない。
+  ブラウザ版にはネイティブのスプラッシュが無いため、これが本体になる。
+  消すのは app.js の hideSplash で、ネイティブ側と同時に消える。
+-->
+<div id="splash">
+  <img src="img/splash_for_browser.png" alt="さばとマップ" width="214" height="77">
+</div>
+<style>
+  #splash {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #0068B1;
+    transition: opacity .25s ease-out;
+  }
+  #splash.hidden { opacity: 0; pointer-events: none; }
+</style>
 <div id="map"></div>
 <div id="compass" class="hidden"></div>
 <div id="ui"></div>


### PR DESCRIPTION
起動時間の短縮を4段階で。**各段階で `node test/e2e/startup.mjs 7` を回して数字を残しています。**

## まとめ

| | 段階0 | 1 スプラッシュ | 2 初回フェード | 3 ベースタイル | 4 preact |
|---|---:|---:|---:|---:|---:|
| **スプラッシュが消える（Android）** | **7000** | **2001** | 2004 | 2001 | **2001** |
| スプラッシュが消える（iOS） | 2067 | 2001 | 2004 | 2001 | 2001 |
| 地図が描き終わる | 475 | 476 | 364 | 359 | **345** |
| ベースタイルが可視化 | 588 | 593 | 597 | 373 | **358** |
| 全部落ち着いた | 860 | 852 | 875 | 646 | **616** |
| first-contentful-paint | 104 | 32 | 28 | 28 | **28** |
| 成果物 | 628 KB | 628 KB | 628 KB | 628 KB | **462 KB** |

**Android は 7 秒から 2 秒。**残りの内部処理も 860 → 616ms になりました。

計測はネットワークをスタブした e2e 環境なので通信の揺らぎが入りません。デスクトップでの絶対値に意味はなく、**同じ機械での前後比較**として読んでください。

---

## 1. スプラッシュ：Android 7秒 → 2秒、ブラウザ版にも追加

`config.xml` の `SplashScreenDelay=7000` は**生きていました**。`cordova-plugin-splashscreen` は入っていませんが、**cordova-android 15 と cordova-ios 8 はスプラッシュをプラットフォーム本体で持っています。**

```java
// cordova-android 15.1.0 SplashScreenPlugin.java
if (autoHide && delayTime != DEFAULT_DELAY_TIME) {   // DEFAULT は -1
    postDelayed(() -> keepOnScreen = false, delayTime);
}
```

`SplashScreenDelay` を指定すると `onPageFinished` では閉じません（排他）。さらに

```java
if (action.equals("hide") && autoHide == false) { ... } else { return false; }
```

`autoHide` の既定は true なので、`app.js` が呼んでいた `navigator.splashscreen.hide()` は **Android では無視されていました。**

| | 変更前 |
|---|---|
| Android | **7.0 秒（固定）** |
| iOS | `AutoHideSplashScreen=false` + `setTimeout(hide, 2000)` で約 2 秒 |
| ブラウザ | 何も出ない |

アプリの準備は 0.5 秒で終わっています。

### どうしたか

`AutoHideSplashScreen=false` を全プラットフォーム共通にし、`SplashScreenDelay` を外しました。消すのはアプリ側です。

- **最短 2 秒は出す**（ロゴを見せるため）
- 地図がそれより遅ければ、描き終わるまで延ばす（白い画面を見せない）
- 8 秒で打ち切る（通信が死んでいても必ず消える）

**ブラウザ版は `www/index.html` の `#splash` を新設しました。** `app.css` より先に出したいのでスタイルはインラインです。副作用として first-contentful-paint が 104 → 28ms になりました。

該当処理は `platformId !== "browser"` のブロックの外へ出しました。**中に入っていたせいでブラウザ版は一切通っていませんでした。**

### 効かない設定を落とした

`ShowSplashScreenSpinner`、`SplashShowOnlyFirstTime`、browser の `SplashScreen` 系6件。**どのプラットフォームも読んでいません。**

## 2. 起動直後のフロア読み込みでフェードを飛ばす

`setFloorId` は既定でクロスフェードします。フェーズを追いました。

```
 92.6  fade phase 0（タイル待ち）
134.3  fade phase 1（配架図の不透明度 0→1）
303.9  fade phase 2（ラベルを出す）
470.3  fade 終了
```

**初回はクロスフェードする相手がいません。** 退避先の `tileB` に入るのは `tileA.getSource()` で、起動時はこれが `null` です。フロア切り替えの演出がそのまま起動時にも走っていました。

`kanilayer.floorId` の初期値 `false` を見て初回だけ `animation=false` にします。フロアを切り替えるときのフェードはこれまで通りです。

## 3. ベースタイルの 500ms 固定待ちをやめる

隠している理由（起動直後は日本全体のビューなので、寄せる前に出すと日本地図が一瞬見える）は正しいのですが、**実測ではビューが施設へ寄るのは 100ms 前後**で、400ms ぶん無駄に待っていました。`rendercomplete` に合わせます。

## 4. react/react-dom → preact/compat

esbuild の `alias` で差し替え。ソースは react のまま書けます。**628 KB → 462 KB（−26%）。**

**`vitest.config.mjs` にも同じ alias を入れました。** 揃えないとテストは react を、実機は preact を動かすことになり、マウントテストが本番と別物を検証してしまいます。`act` だけは経路が違い、react は本体から出しますが preact は `preact/test-utils` にあります。

**e2e の基準画像 8 枚が 1 枚も変わりませんでした。** 描画結果は画素まで同じです。

---

## 測る道具

```bash
node test/e2e/startup.mjs 7
```

スプラッシュは cordova-browser に実装が無いので直接は測れません。代わりに **`navigator.splashscreen.hide()` が呼ばれた時刻**を印にしてあります。実機のスプラッシュはその時刻まで出続けます。

## 実機で見てほしいところ

- **Android で起動が体感どれだけ変わったか**（7秒 → 2秒）
- スプラッシュが 2 秒で消えたあと、**すぐ配架図が見えているか**（白い画面を挟まないか）
- 日本地図が一瞬見えないか（3 の変更で出る可能性があるのはここ）
- ブラウザ版のスプラッシュの見た目

## 検証

各段階で `npm test`（31件）と e2e（13件）を通しています。e2e は `#splash` が消えるのを待つようにしました。全画面を覆うので、待たないと地図の代わりにこれを撮ってしまいます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
