### PR TITLE
ci: Play への認証を OIDC にし、公開リポジトリから社内情報を外す

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -17,17 +17,29 @@ name: Android テスト版の配信
 #   config.xml の android-versionCode を先に上げること。
 #   ここで上げた番号は production の下限にもなる（トラックをまたいで比較される）。
 #
+# ## 認証
+#
+# GitHub の OIDC トークンを Workload Identity Federation で交換する。
+# **Play へ上げる鍵はリポジトリに置かない。**
+#
+# アップロード側のアクションは認証情報を自前で読まず、GOOGLE_APPLICATION_CREDENTIALS
+# を立てて google-auth-library の ADC に任せている。そこへ WIF の認証情報ファイルの
+# パスを渡している（serviceAccountJson は「パス」を受け取る入力）。
+#
 # ## 動かす前に要るもの
 #
-# リポジトリの Secrets に3つ。README の「Androidリリース手順」も参照。
+# Variables（秘密ではないので変数側）
+#   GCP_WORKLOAD_IDENTITY_PROVIDER  google-github-actions/auth に渡す provider の完全名
+#   GCP_PLAY_DEPLOYER_SA            なりすます先のサービスアカウント
+#   ANDROID_KEY_ALIAS               keystore の鍵エイリアス
 #
-#   ANDROID_KEYSTORE_BASE64    1Password の keystore を base64 にしたもの
-#                              op document get yc7l6u4qqffwdaawb5aauhfmbm | base64 -w0
-#   ANDROID_KEYSTORE_PASSWORD  keystore のパスワード（keyPassword も同じ）
-#   PLAY_SERVICE_ACCOUNT_JSON  Play Developer API のサービスアカウント鍵（JSON そのもの）
+# Secrets
+#   ANDROID_KEYSTORE_BASE64         署名用 keystore を base64 にしたもの
+#   ANDROID_KEYSTORE_PASSWORD       keystore のパスワード（keyPassword も同じ）
 #
-# サービスアカウントは Google Cloud で作り、Play Console の
-# ユーザーと権限 →「リリースを管理」を付ける。反映に時間がかかることがある。
+# サービスアカウントは Play Console の「ユーザーと権限」へ招待し、アプリ単位で
+# 「テスト版トラックとしてのアプリのリリース」を付ける。
+# その中に「内部共有用の APK のアップロード」が含まれる。
 #
 # **secrets を使うので pull_request では絶対に走らせない。** このリポジトリは
 # public で、同一リポジトリのブランチからの PR には secrets が渡る。
@@ -61,28 +73,33 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      # 必要な Secrets が無い状態で走らせても、Gradle まで進んでから落ちて
+      # 設定が足りない状態で走らせても、Gradle まで進んでから落ちて
       # 原因が分かりにくい。最初に見て、無ければここで止める
-      - name: Secrets の確認
+      - name: 設定の確認
         env:
+          WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          DEPLOYER_SA: ${{ vars.GCP_PLAY_DEPLOYER_SA }}
+          KEY_ALIAS: ${{ vars.ANDROID_KEY_ALIAS }}
           KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          PLAY_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           set -euo pipefail
           missing=""
-          [ -n "$KEYSTORE" ] || missing="$missing ANDROID_KEYSTORE_BASE64"
-          [ -n "$KEYSTORE_PASSWORD" ] || missing="$missing ANDROID_KEYSTORE_PASSWORD"
-          [ -n "$PLAY_JSON" ] || missing="$missing PLAY_SERVICE_ACCOUNT_JSON"
+          [ -n "$WIF_PROVIDER" ] || missing="$missing vars.GCP_WORKLOAD_IDENTITY_PROVIDER"
+          [ -n "$DEPLOYER_SA" ] || missing="$missing vars.GCP_PLAY_DEPLOYER_SA"
+          [ -n "$KEY_ALIAS" ] || missing="$missing vars.ANDROID_KEY_ALIAS"
+          [ -n "$KEYSTORE" ] || missing="$missing secrets.ANDROID_KEYSTORE_BASE64"
+          [ -n "$KEYSTORE_PASSWORD" ] || missing="$missing secrets.ANDROID_KEYSTORE_PASSWORD"
           if [ -n "$missing" ]; then
-            echo "::error::Secrets が足りない:$missing"
-            echo "設定方法は .github/workflows/android-deploy.yml の先頭を読んでください"
+            echo "::error::設定が足りない:$missing"
+            echo "何を入れるかは .github/workflows/android-deploy.yml の先頭を読んでください"
             exit 1
           fi
 
@@ -123,17 +140,17 @@ jobs:
       # keystore とパスワードを置く。どちらも作業ディレクトリの外に出さない。
       # build-ci.json は .gitignore 済み。
       #
-      # JSON は node で書く。ランナーの image（ghcr.io/actions/actions-runner）は
-      # 最小構成で jq が入っている保証がない。node は setup-node 済みなので確実
+      # JSON は node で書く。ランナーの image は最小構成で jq が入っている保証がない。
+      # node は setup-node 済みなので確実
       - name: 署名の準備
         env:
           KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ vars.ANDROID_KEY_ALIAS }}
         run: |
           set -euo pipefail
           umask 077
           printf '%s' "$KEYSTORE" | base64 -d > sabatomap-keystore.jks
-          # keyAlias は calil、keyPassword は keystore と同じ（README の記載どおり）
           node -e '
             const fs = require("node:fs");
             const path = require("node:path");
@@ -141,7 +158,7 @@ jobs:
               android: { release: {
                 keystore: path.resolve("sabatomap-keystore.jks"),
                 storePassword: process.env.KEYSTORE_PASSWORD,
-                alias: "calil",
+                alias: process.env.KEY_ALIAS,
                 password: process.env.KEYSTORE_PASSWORD,
                 keystoreType: "jks",
               } },
@@ -168,11 +185,21 @@ jobs:
           echo "VERSION_CODE=$code" >> "$GITHUB_ENV"
           echo "versionCode: $code"
 
+      # OIDC で認証情報ファイルを作る。鍵は発行されず、数分で失効する
+      - name: Google Cloud の認証
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_PLAY_DEPLOYER_SA }}
+
       - name: Play へ上げる
         id: upload
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          # 鍵ではなく WIF の認証情報ファイル。中身は検証されず、
+          # GOOGLE_APPLICATION_CREDENTIALS に立てられるだけ
+          serviceAccountJson: ${{ steps.auth.outputs.credentials_file_path }}
           packageName: jp.calil.sabatomap
           releaseFiles: ${{ env.AAB_PATH }}
           # push のときは常に internalsharing。手動実行だけ internal を選べる

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,4 +500,5 @@ cordova prepare
 1. config.xmlの`android-versionCode`と`version`を更新
 2. 1Passwordからkeystoreをダウンロード（「さばとマップ」として保存）
 3. keystoreをプロジェクトルートに配置
-4. 適切な署名でリリース版をビルド（keyAlias: calil）
+4. 適切な署名でリリース版をビルド（鍵エイリアスは 1Password の同じ項目にある。
+   **public リポジトリなので値は書かないこと**）

--- a/README.md
+++ b/README.md
@@ -141,18 +141,15 @@ cordova plugin add https://github.com/CALIL/cordova-plugin-device-orientation
 | `internalsharing`（既定） | ビルドごとに URL。**versionCode が重複していても通る**ので自動配信に向く。トラックには影響しない |
 | `internal`（内部テスト） | Play 経由で配られ更新も自動。**`android-versionCode` を先に上げること**。ここで使った番号は production の下限にもなる |
 
-### 動かす前に要るもの
+### 認証は OIDC で、鍵は置きません
 
-リポジトリの Secrets に3つ。**まだ設定されていません。**
+GitHub の OIDC トークンを Workload Identity Federation で交換します。
+**Play へ上げる鍵はこのリポジトリに置きません。**
 
-| Secret | 中身 |
-|---|---|
-| `ANDROID_KEYSTORE_BASE64` | `op document get yc7l6u4qqffwdaawb5aauhfmbm \| base64 -w0` の出力 |
-| `ANDROID_KEYSTORE_PASSWORD` | keystore のパスワード（1Password のラベル）。keyPassword も同じ |
-| `PLAY_SERVICE_ACCOUNT_JSON` | Play Developer API のサービスアカウント鍵（JSON そのまま） |
-
-サービスアカウントは Google Cloud で作り、**Play Console → ユーザーと権限**で
-「リリースを管理」を付けます。権限の反映に時間がかかることがあります。
+必要な Variables / Secrets は `.github/workflows/android-deploy.yml` の先頭に
+一覧があります。**まだ設定されていないので、いまのままでは最初のステップで止まります。**
+値と、Google Cloud 側のリソース（サービスアカウントと Workload Identity の紐付け）は
+社内の非公開リポジトリで管理しています。
 
 **このリポジトリは public です。** ワークフローは `pull_request` では走らせていません。
 同一リポジトリのブランチからの PR には secrets が渡るためで、

--- a/README.md
+++ b/README.md
@@ -167,20 +167,18 @@ npx cordova build android --release -- --packageType=bundle
 
 `--packageType=bundle` を付けないと AAB ではなく APK ができる。Google Play が要求するのは AAB。
 
-1Password から、さばとマップの keystore をダウンロードしてプロジェクトのルートに保存する。
+1Password の「さばとマップ」の keystore をダウンロードして、プロジェクトのルートに
+`sabatomap-keystore.jks` として保存する（`.gitignore` 済み）。
+パスワードと鍵エイリアスも同じ項目に入っている。
 
 ```bash
-op document get yc7l6u4qqffwdaawb5aauhfmbm --output ./sabatomap-keystore.jks
-```
-
-keystoreのパスワードは、1Passwordのラベルに保存してある<br>
-keyAliasはcalil<br>
-keyPasswordはkeystoreと同じ
-
-```bash
-jarsigner -keystore ./sabatomap-keystore.jks platforms/android/app/build/outputs/bundle/release/app-release.aab calil
+op document get <item> --output ./sabatomap-keystore.jks
+jarsigner -keystore ./sabatomap-keystore.jks platforms/android/app/build/outputs/bundle/release/app-release.aab <alias>
 jarsigner -verify platforms/android/app/build/outputs/bundle/release/app-release.aab
 ```
+
+**このリポジトリは public なので、item ID や鍵エイリアスは書かない。**
+必要な値は 1Password 側にある。
 
 `npm run release` は `cordova run android --release` で、**実機かエミュレータへ送り込む操作**なので
 ストア用の成果物は作れない。混同しないこと。


### PR DESCRIPTION
#178 のマージ後に押し損ねた分と、公開リポジトリの棚卸しです。

## 1. Play への認証を OIDC にした

アップロード側のアクション（`r0adkll/upload-google-play`）は認証情報を自前で読んでいませんでした。

```ts
// src/edits.ts
const auth = new google.auth.GoogleAuth({
  scopes: ['https://www.googleapis.com/auth/androidpublisher']
});
```

やっているのは `GOOGLE_APPLICATION_CREDENTIALS` を立てることだけ（`src/main.ts`）。**実体は ADC** です。`google-auth-library` 9 系は `external_account` を ADC として解決できるので、`google-github-actions/auth` が書き出した認証情報ファイルのパスを `serviceAccountJson`（**パス**を受け取る入力）へ渡せば通ります。

**Play へ上げる無期限の鍵をリポジトリに置かずに済みます。**

## 2. 公開リポジトリから社内情報を外した

ワークフローに直書きしていた値を Variables / Secrets へ移しました。

| | |
|---|---|
| Variables | `GCP_WORKLOAD_IDENTITY_PROVIDER` / `GCP_PLAY_DEPLOYER_SA` / `ANDROID_KEY_ALIAS` |
| Secrets | `ANDROID_KEYSTORE_BASE64` / `ANDROID_KEYSTORE_PASSWORD` |

あわせて、**以前から README と CLAUDE.md に載っていた** 1Password の item ID と鍵エイリアスも外しました。どちらもそれ単体で使えるものではありませんが、社内の具体値を public に置く理由がありません。手順は残したまま値だけ 1Password 側に寄せています。

Google Cloud 側のリソース定義（サービスアカウントと Workload Identity の紐付け）は、**非公開リポジトリ側の Terraform** で管理します。

## 検証

`npm test` 35件。zizmor は指摘なし。

**配信そのものはまだ一度も走らせていません**（Variables / Secrets が未設定のため、最初のステップで止まります）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
