### PR TITLE
ci: 焼かれた versionCode を成果物で確かめてから上げる

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -205,6 +205,11 @@ jobs:
         if: always()
         run: rm -f sabatomap-keystore.jks build-ci.json
 
+      # 成果物そのものを見る。
+      #
+      # 「--versionCode を渡したつもり」で終わらせない。AGP がマージした
+      # マニフェストを読んで、狙った番号が実際に焼かれたかを確かめ、
+      # 違えばここで止める。**上げてしまってからでは端末側でしか分からない。**
       - name: できたものを確認
         run: |
           set -euo pipefail
@@ -212,14 +217,22 @@ jobs:
           [ -n "$aab" ] || { echo "::error::AAB が見つからない"; exit 1; }
           ls -lh "$aab"
           echo "AAB_PATH=$aab" >> "$GITHUB_ENV"
-          # 差し替えていないとき（internal トラック）だけ config.xml から拾う
-          if [ -z "${VERSION_CODE:-}" ]; then
-            code=$(grep -o 'android-versionCode="[0-9]*"' config.xml | grep -o '[0-9]*')
-            echo "VERSION_CODE=$code" >> "$GITHUB_ENV"
-            echo "versionCode: $code"
-          else
-            echo "versionCode: $VERSION_CODE"
+
+          manifest=$(find platforms/android/app/build/intermediates -name 'AndroidManifest.xml' -path '*erged*' | head -1)
+          if [ -z "$manifest" ]; then
+            echo "::error::マージ済みマニフェストが見つからない。versionCode を確認できない"
+            exit 1
           fi
+          built=$(grep -o 'android:versionCode="[0-9]*"' "$manifest" | grep -o '[0-9]*' | head -1)
+          name=$(grep -o 'android:versionName="[^"]*"' "$manifest" | sed 's/.*="//;s/"//' | head -1)
+          echo "焼かれた versionCode: $built  versionName: $name"
+
+          if [ -n "${VERSION_CODE:-}" ] && [ "$built" != "$VERSION_CODE" ]; then
+            echo "::error::versionCode が指定と違う（指定 $VERSION_CODE / 実際 $built）"
+            exit 1
+          fi
+          echo "VERSION_CODE=$built" >> "$GITHUB_ENV"
+          echo "VERSION_NAME=$name" >> "$GITHUB_ENV"
 
       # OIDC で認証情報ファイルを作る。鍵は発行されず、数分で失効する
       - name: Google Cloud の認証
@@ -252,7 +265,8 @@ jobs:
             echo "## Play へ上げました"
             echo ""
             echo "- 配信先: \`$TRACK\`"
-            echo "- versionCode: \`$VERSION_CODE\`"
+            echo "- versionCode: \`$VERSION_CODE\`（**マージ済みマニフェストで確認済み**）"
+            echo "- versionName: \`$VERSION_NAME\`（ストアの表示はこちら。テスト版でも本番と同じ）"
             echo "- コミット: \`${GITHUB_SHA:0:7}\`"
             if [ -n "$URLS" ]; then
               echo ""


### PR DESCRIPTION
ci: 焼かれた versionCode を成果物で確かめてから上げる

端末で「ダウンロードできません」が続いている。--versionCode を渡してはいるが、
**それが AAB に実際に入ったかをログから確認できない**（cordova は gradle の
引数を出さない）。指定と実物がずれていても、上げてしまってからでないと
気づけない状態だった。

AGP がマージしたマニフェストを読み、狙った番号と違えばそこで止める。
versionName も出す。

**ストアの表示は versionName（3.0.8）** で、これはテスト版でも本番と同じ。
「表示が 3.0.8 のまま」は versionCode が効いているかどうかの手がかりにならないので、
まとめにその旨も書く。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BsERiWbzZwB6EdGoyyqcpT
