### PR TITLE
fix: 測位失敗時の Bluetooth の決め打ちをやめる

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -163,8 +163,44 @@ var loadFloor = function (id) {
   return setTimeout(fitFloor, 100);
 };
 
+// 測位できなかった理由を切り分けるための計数。
+//
+// ranging は圏内にビーコンが無くても1秒ごとに空配列で呼ばれる。だから
+// 「呼ばれた回数」と「見えたビーコンの総数」は別のことを教えてくれる。
+//
+//   呼ばれていない       → ranging がそもそも始まっていない
+//   呼ばれるが総数が0    → スキャンは回っているがビーコンが1本も見えていない
+//
+// 後者は館外にいるとき（正常）と、Android 12 以降で「付近のデバイス」または
+// 位置情報の実行時許可が無いときの両方で起きる。**許可が無い場合はエラーではなく
+// 空のスキャン結果が返る**ので、JS からはこの2つを区別できない。
+// 区別できないぶんは文言で両方に触れる。
+var rangingCallbacks = 0;
+var beaconsSeen = 0;
+
 var didRangeBeaconsInRegion = function (beacons) {
+  rangingCallbacks++;
+  beaconsSeen += beacons.length;
   return kanikama.push(beacons);
+};
+
+/**
+ * 測位できなかったときの案内を選ぶ
+ *
+ * 「現在地を取得できませんでした」だけだと、館外にいるのか、権限が無くて
+ * BLE が一切見えていないのかが区別できず、利用者も開発者も次の手を打てない。
+ */
+var locateFailureMessage = function () {
+  if (!(typeof cordova !== "undefined" && cordova !== null) || cordova.platformId === "browser") {
+    return "現在地を取得できませんでした";
+  }
+  if (rangingCallbacks === 0) {
+    return "ビーコンの検出を開始できていません。アプリの権限を確認してください";
+  }
+  if (beaconsSeen === 0) {
+    return "ビーコンが見つかりません。館内で、位置情報と「付近のデバイス」を許可してお試しください";
+  }
+  return "現在地を取得できませんでした";
 };
 
 // スプラッシュを出しておく最短時間（ミリ秒）。ロゴを見せるための下限で、
@@ -500,10 +536,11 @@ var waitPosition = function () {
 
     if (waitingPosition === 0) {
       if (kanikama.currentPosition === null) {
-        // Bluetooth の状態を先に確かめられない環境では、ここでしか伝えられない
-        UI.notify(canTrustBluetoothState()
-          ? "現在地を取得できませんでした"
-          : "現在地を取得できませんでした。BluetoothがONか確かめてください");
+        // かつては Android でだけ「BluetoothがONか確かめてください」と足していたが、
+        // **測位できない理由の大半は館外にいてビーコンが無いこと**で、
+        // Bluetooth が入っていても出てしまい誤解を招いた。
+        // 決め打ちをやめ、ranging の実績から選ぶ
+        UI.notify(locateFailureMessage());
       }
       if (kanikama.currentPosition && kanikama.accuracy > 10) {
         UI.notify("棚の中に入ると正確な位置がわかります");
@@ -613,6 +650,29 @@ export default class App {
    */
   getMarker() {
     return kanimarker;
+  }
+
+  /**
+   * 測位まわりの実況を返す
+   *
+   * 実機で「現在地が出ない」と言われたときに、どこで止まっているかを
+   * その場で切り分けるための入口。Chrome の chrome://inspect から
+   * `app.getDiagnostics()` を叩けば、ビルドし直さずに状態が読める。
+   *
+   *   ranging が 0            → 検出が始まっていない（権限・プラグイン）
+   *   ranging はあるが beacons が 0 → スキャンは回っているが1本も見えていない
+   *   beacons はあるが position が null → 測位アルゴリズムまで届いていない
+   */
+  getDiagnostics() {
+    return {
+      platform: (typeof cordova !== "undefined" && cordova !== null) ? cordova.platformId : "web",
+      ranging: rangingCallbacks,
+      beacons: beaconsSeen,
+      facility: kanikama.currentFacility ? kanikama.currentFacility.id : null,
+      floor: kanikama.currentFloor ? kanikama.currentFloor.id : null,
+      position: kanikama.currentPosition,
+      heading: kanikama.heading
+    };
   }
 }
 

--- a/test/kanikama.test.js
+++ b/test/kanikama.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import Kanikama from '../src/libs/kanikama.js';
+import rules from '../src/sabae.json';
+
+// 測位そのものを実データで確かめる。
+//
+// ここが無い間、ビーコンからの測位は1行も検証されていなかった。
+// jsdom で足りる（地図もキャンバスも要らない）。
+//
+// 座標について: sabae.json は latitude に経度、longitude に緯度が入っている。
+// 名前が実態と逆なので、期待値もその並びで書く。詳しくは kanikama.js 冒頭。
+
+const UUID = '00000000-71C7-1001-B000-001C4D532518';
+
+/** 実機の delegate.didRangeBeaconsInRegion と同じ形 */
+const beacon = (minor, rssi, major = 105) => ({ uuid: UUID, major, minor, rssi });
+
+/** app.js の初期化と同じ設定にする */
+const newKanikama = () => {
+  const k = new Kanikama();
+  k.facilities_ = rules;
+  k.setTimeout(5000);
+  return k;
+};
+
+const floor7 = () => rules[0].floors.find((f) => f.id === '7') ?? rules[0].floors[0];
+
+describe('Kanikama', () => {
+  let k;
+  beforeEach(() => {
+    k = newKanikama();
+  });
+
+  it('sabae.json の 1F に minor 115 が nearest1 の候補として入っている', () => {
+    const entry = floor7().nearest1.find((p) => p.beacon.minor === 115);
+    expect(entry).toBeDefined();
+    // latitude 側が経度（136 台）。ここが入れ替わると測位が福井県から飛び出す
+    expect(entry.latitude).toBeGreaterThan(136);
+    expect(entry.longitude).toBeGreaterThan(35);
+    expect(entry.longitude).toBeLessThan(36);
+  });
+
+  it('ビーコン1本（minor 115）で施設・フロア・現在地が決まる', () => {
+    k.push([beacon(115, -60)]);
+
+    expect(k.currentFacility).not.toBeNull();
+    expect(k.currentFloor).not.toBeNull();
+    expect(k.currentFloor.id).toBe('7');
+
+    expect(k.currentPosition).not.toBeNull();
+    expect(k.currentPosition.algorithm).toBe('nearest1');
+    expect(k.currentPosition.beacon.minor).toBe(115);
+  });
+
+  it('change:position が通知される', () => {
+    const seen = [];
+    k.on('change:position', (p) => seen.push(p));
+    k.push([beacon(115, -60)]);
+    expect(seen.length).toBe(1);
+    expect(seen[0].algorithm).toBe('nearest1');
+  });
+
+  it('rssi が 0 のビーコンは測位に使わない', () => {
+    k.push([beacon(115, 0)]);
+    expect(k.currentPosition).toBeNull();
+  });
+
+  it('施設に無いビーコンでは何も決まらない', () => {
+    k.push([beacon(9999, -60, 999)]);
+    expect(k.currentFacility).toBeNull();
+    expect(k.currentPosition).toBeNull();
+  });
+});


### PR DESCRIPTION
実機で「Bluetooth が有効なのに『BluetoothがONか確かめてください』が出る」という報告を受けた対応です。

## 何が起きていたか

#177 で、Android は `BluetoothAdapter.isEnabled()` を読めない（`BLUETOOTH_CONNECT` が要る）ため状態を先に判定できず、測位失敗時の文言に Bluetooth の助言を足していました。

ところが**測位できない理由の大半は館外にいてビーコンが無いこと**で、Bluetooth が入っていても必ず出ます。外れることの多い助言でした。

なお、この吹き出しが出ること自体は #176 が効いている証拠でもあります。以前の Android では現在地ボタンが「測定できません」で押せませんでした。

## UI は増やさず、元の1文に戻す

`UI.notify("現在地を取得できませんでした")` の1文だけにしました。#177 で足した Bluetooth への言及が外れ、**3.0.8 と同じ4文言**に戻っています。

```
現在地を取得できませんでした
棚の中に入ると正確な位置がわかります
この機種は現在地を測定できません
BluetoothをONにしてください
```

切り分けは文言を増やさず、下の `app.getDiagnostics()` で行います。

## `app.getDiagnostics()`

実機で止まった場所をその場で読めるようにしました。`chrome://inspect` から叩けば、ビルドし直さずに状態が見えます。UI には出しません。

```js
app.getDiagnostics()
// { platform: "android", ranging: 42, beacons: 0,
//   facility: null, floor: null, position: null, heading: 137 }
```

| 読み方 | 意味 |
|---|---|
| `ranging` が 0 | 検出が始まっていない（権限・プラグイン） |
| `ranging` はあるが `beacons` が 0 | スキャンは回っているが1本も見えていない |
| `beacons` はあるが `position` が null | 測位アルゴリズムまで届いていない |

`ranging` は圏内にビーコンが無くても1秒ごとに空配列で呼ばれるので、この2つは別のことを教えてくれます。

2番目は館外にいるとき（正常）と、Android 12 以降で「付近のデバイス」または位置情報の実行時許可が無いときの両方で起きます。**許可が無い場合はエラーではなく空のスキャン結果が返る**ので、JS からはこの2つを区別できません。

`BLUETOOTH_CONNECT` は測距には要りません（AltBeacon の要件は `ACCESS_FINE_LOCATION` と `BLUETOOTH_SCAN`）。#176 の判断は変えていません。

## 測位の回帰テストを入れた

ビーコンからの測位は、これまで1行も検証されていませんでした。実データ（`src/sabae.json`）で施設・フロア・現在地の確定までを通します。地図もキャンバスも要らないので jsdom で足ります。

```
✓ sabae.json の 1F に minor 115 が nearest1 の候補として入っている
✓ ビーコン1本（minor 115）で施設・フロア・現在地が決まる
✓ change:position が通知される
✓ rssi が 0 のビーコンは測位に使わない
✓ 施設に無いビーコンでは何も決まらない
```

## 調査で切り分けたこと

「反応がない」の原因を探して、JS 側は一通り潰してあります。いずれも問題なしでした。

- APK のマニフェストに `BLUETOOTH_SCAN` / `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` が入っている
- `plugins/` の撤去（#176）でプラグイン本体は変わっていない（45ファイル全て vendoring 時と一致）
- 成果物 `all.js` に ranging の呼び出しも施設データも入っている
- 測位ロジックは実データでビーコン1本から現在地を出せる（上のテスト）
- 3.0.8 との差分で、ranging を組み立てている箇所は1行も変わっていない

残るのは端末側の実行時許可の状態で、そこは `getDiagnostics()` で見えるようになります。

## 確認

- `npm test` 40件グリーン
- `test/e2e` 16件グリーン
