### PR TITLE
fix: 測位失敗の文言を元に戻す（UI は変えない）

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -163,7 +163,7 @@ var loadFloor = function (id) {
   return setTimeout(fitFloor, 100);
 };
 
-// 測位できなかった理由を切り分けるための計数。
+// 測位できなかった理由を切り分けるための計数。app.getDiagnostics() で読む。
 //
 // ranging は圏内にビーコンが無くても1秒ごとに空配列で呼ばれる。だから
 // 「呼ばれた回数」と「見えたビーコンの総数」は別のことを教えてくれる。
@@ -174,7 +174,6 @@ var loadFloor = function (id) {
 // 後者は館外にいるとき（正常）と、Android 12 以降で「付近のデバイス」または
 // 位置情報の実行時許可が無いときの両方で起きる。**許可が無い場合はエラーではなく
 // 空のスキャン結果が返る**ので、JS からはこの2つを区別できない。
-// 区別できないぶんは文言で両方に触れる。
 var rangingCallbacks = 0;
 var beaconsSeen = 0;
 
@@ -182,25 +181,6 @@ var didRangeBeaconsInRegion = function (beacons) {
   rangingCallbacks++;
   beaconsSeen += beacons.length;
   return kanikama.push(beacons);
-};
-
-/**
- * 測位できなかったときの案内を選ぶ
- *
- * 「現在地を取得できませんでした」だけだと、館外にいるのか、権限が無くて
- * BLE が一切見えていないのかが区別できず、利用者も開発者も次の手を打てない。
- */
-var locateFailureMessage = function () {
-  if (!(typeof cordova !== "undefined" && cordova !== null) || cordova.platformId === "browser") {
-    return "現在地を取得できませんでした";
-  }
-  if (rangingCallbacks === 0) {
-    return "ビーコンの検出を開始できていません。アプリの権限を確認してください";
-  }
-  if (beaconsSeen === 0) {
-    return "ビーコンが見つかりません。館内で、位置情報と「付近のデバイス」を許可してお試しください";
-  }
-  return "現在地を取得できませんでした";
 };
 
 // スプラッシュを出しておく最短時間（ミリ秒）。ロゴを見せるための下限で、
@@ -536,11 +516,13 @@ var waitPosition = function () {
 
     if (waitingPosition === 0) {
       if (kanikama.currentPosition === null) {
-        // かつては Android でだけ「BluetoothがONか確かめてください」と足していたが、
+        // Bluetooth に言及しない。
+        //
+        // #177 で Android だけ「BluetoothがONか確かめてください」を足したが、
         // **測位できない理由の大半は館外にいてビーコンが無いこと**で、
         // Bluetooth が入っていても出てしまい誤解を招いた。
-        // 決め打ちをやめ、ranging の実績から選ぶ
-        UI.notify(locateFailureMessage());
+        // 切り分けは文言を増やさず app.getDiagnostics() で行う
+        UI.notify("現在地を取得できませんでした");
       }
       if (kanikama.currentPosition && kanikama.accuracy > 10) {
         UI.notify("棚の中に入ると正確な位置がわかります");


### PR DESCRIPTION
#183 で、測位に失敗したときの吹き出しを3通りに増やしてしまいました。UI を勝手に変えるべきではなかったので戻します。

## 直すこと

`UI.notify("現在地を取得できませんでした")` の1文だけにします。**3.0.8 と同じ4文言**に戻ります。

```
現在地を取得できませんでした
棚の中に入ると正確な位置がわかります
この機種は現在地を測定できません
BluetoothをONにしてください
```

#177 で足していた「BluetoothがONか確かめてください」もこれで外れます。Android では Bluetooth の状態を先に判定できない（`BLUETOOTH_CONNECT` が要る）ため足したものでしたが、**測位できない理由の大半は館外にいてビーコンが無いこと**で、Bluetooth が入っていても出てしまい誤解を招いていました。

## 残すもの

切り分けは文言を増やさず `app.getDiagnostics()`（#183 で追加、UI には出ない）で行います。`ranging` / `beacons` の計数もそのために残します。

```js
app.getDiagnostics()
// { platform: "android", ranging: 42, beacons: 0,
//   facility: null, floor: null, position: null, heading: 137 }
```

## 確認

- `npm test` 40件グリーン
- `test/e2e` 16件グリーン
- 変更は `src/app.js` のみ（6行追加・24行削除）
