### PR TITLE
feat: デバッグビルドでビーコンの受信状況を画面に出す

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -76,9 +76,16 @@ jobs:
       - name: Install
         run: npm ci
 
-      # www/ を作る。これが無いと空のアプリが焼き上がる
+      # www/ を作る。これが無いと空のアプリが焼き上がる。
+      #
+      # ここは **debug ビルド**。__DEBUG__ が立ち、ビーコンの受信状況が画面に出る。
+      # 実機で測位が出ないとき、USB を繋がずに切り分けられるようにするため。
+      # minify されず inline sourcemap が付くので成果物は大きくなるが、
+      # 配信用ではないので構わない（配信は android-deploy.yml が release で作る）。
+      #
+      # release ビルドが通ることは ci.yml が `npm run copy` で見ている
       - name: web 側をビルド
-        run: npm run copy
+        run: npm run copy:debug
 
       # config.xml と package.json の cordova.plugins から復元する。
       # platforms/android は .gitignore されているので毎回作り直し

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,11 @@ false に畳まれ、`beacondebug.js` ごとバンドルから落ちます**（`
 見え方を確かめるには `test/e2e/shot-debug.mjs` を使います（spec ではないので
 `playwright test` では拾われません）。
 
+**`copy:debug` のあとは `npm run copy` に戻してからコミットすること。**
+`www/css/app.css` は追跡されている生成物なので、minify されていない版
+（9.5KB → 640行ほど増える）がそのまま差分に出ます。`www/js/all.js` は
+追跡外なので影響しません。
+
 **追従モードはブラウザでは到達できません。** `invalidateLocator`（`app.js`）が
 `change:mode` を購読していて、`cordova.plugins.BluetoothStatus.hasBTLE` か
 `BTenabled` が偽なら**その場で `setMode("normal")` に戻す**からです。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,43 @@ artifact から持ち帰ってコミットします。
 | `app.pushBeacons(beacons)` | 本番で cordova のプラグインが呼ぶ `didRangeBeaconsInRegion` と同じ入口 |
 | `app.getMap()` | View の状態を見る / `rendercomplete` を待つ |
 | `app.getMarker()` | `cancelAnimation()` で描画を止める |
+| `app.getDiagnostics()` | 測位の実況（`ranging` / `beacons` / `facility` / `floor` / `position`） |
+
+### 測位が出ないときの切り分け
+
+`app.getDiagnostics()` を読みます。**`ranging` は圏内にビーコンが無くても
+1秒ごとに増える**ので、増えているかどうかで意味が変わります。
+
+| | |
+|---|---|
+| `ranging` が 0 | 検出がそもそも始まっていない（権限・プラグイン） |
+| `ranging` はあるが `beacons` が 0 | スキャンは回っているが1本も見えていない |
+| `beacons` はあるが `position` が null | 測位アルゴリズムまで届いていない |
+
+2番目は**館外にいるとき（正常）と、Android 12 以降で「付近のデバイス」または
+位置情報の実行時許可が無いときの両方**で起きます。許可が無い場合はエラーではなく
+空のスキャン結果が返るので、JS からは区別できません。
+
+### デバッグビルドは同じ内容を画面に出します
+
+実機で測位が出ないとき、USB を繋いで `chrome://inspect` を開ける状況ばかりでは
+ありません。`npm run copy:debug` で作ると、`src/libs/beacondebug.js` が
+検索欄の下に受信状況を出します（`pointer-events: none` なので下のボタンは押せます）。
+
+```
+BLE android  ranging 128（1秒前）
+見えている 115:-62 114:-78
+のべ 342 本  施設 7  フロア 7
+測位 nearest1  誤差 3m  minor 115
+方位 137
+```
+
+`android.yml` が焼く debug APK はこちらです。**`release` では `__DEBUG__` が
+false に畳まれ、`beacondebug.js` ごとバンドルから落ちます**（`npm run copy` の
+成果物を grep して確認すること）。`ci.yml` は従来どおり `npm run copy` を見ています。
+
+見え方を確かめるには `test/e2e/shot-debug.mjs` を使います（spec ではないので
+`playwright test` では拾われません）。
 
 **追従モードはブラウザでは到達できません。** `invalidateLocator`（`app.js`）が
 `change:mode` を購読していて、`cordova.plugins.BluetoothStatus.hasBTLE` か
@@ -411,10 +448,11 @@ npm script の素の browserify へ移った際、replace 工程が無くなっ�
 
 - `npm start` - `www/` を作って `cordova prepare` → ブラウザで実行
 - `npm run watch` - `src/` を見張って `www/` を作り直し続ける
-- `npm run copy` - `www/` を作る（JS・CSS・vendor・json）。**CI が呼ぶのはこれ**
+- `npm run copy` - `www/` を作る（JS・CSS・vendor・json）。**`ci.yml` が呼ぶのはこれ**
+- `npm run copy:debug` - 同じものを minify せず `__DEBUG__` を立てて作る。**`android.yml` が呼ぶのはこれ**
 
 `copy` / `compile` / `build_browser` は同じ `node tools/build.mjs release` の別名です。
-`copy` という名前は `ci.yml` と `android.yml` が呼んでいるので変えないこと。
+`copy` という名前は `ci.yml` が、`copy:debug` は `android.yml` が呼んでいるので変えないこと。
 
 ### ビルド
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "npm run copy && npx cordova prepare && npx cordova run browser",
     "copy": "node tools/build.mjs release",
+    "copy:debug": "node tools/build.mjs debug",
     "compile": "node tools/build.mjs release",
     "build_browser": "node tools/build.mjs release",
     "watch": "node tools/build.mjs watch",

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,9 @@ import Kanimarker from './libs/kanimarker.js';
 import Kanilayer from './libs/kanilayer.js';
 import InitUI from './component/App.jsx';
 import rules from './sabae.json';
+// デバッグビルド専用。__DEBUG__ が false の release では、下の if ごと
+// minify に落とされ、このモジュール自体もバンドルに入らない
+import createBeaconDebug from './libs/beacondebug.js';
 
 var MAPBOX_TOKEN = "pk.eyJ1IjoiY2FsaWxqcCIsImEiOiJxZmNyWmdFIn0.hgdNoXE7D6i7SrEo6niG0w";
 
@@ -163,7 +166,8 @@ var loadFloor = function (id) {
   return setTimeout(fitFloor, 100);
 };
 
-// 測位できなかった理由を切り分けるための計数。app.getDiagnostics() で読む。
+// 測位できなかった理由を切り分けるための計数。
+// app.getDiagnostics() と、デバッグビルドの画面表示から読む。
 //
 // ranging は圏内にビーコンが無くても1秒ごとに空配列で呼ばれる。だから
 // 「呼ばれた回数」と「見えたビーコンの総数」は別のことを教えてくれる。
@@ -176,11 +180,48 @@ var loadFloor = function (id) {
 // 空のスキャン結果が返る**ので、JS からはこの2つを区別できない。
 var rangingCallbacks = 0;
 var beaconsSeen = 0;
+var lastRangeAt = null;
+var lastBeacons = [];
+
+/** デバッグビルドでだけ作られる画面表示。release では丸ごと落ちる */
+var beaconDebug = null;
 
 var didRangeBeaconsInRegion = function (beacons) {
   rangingCallbacks++;
   beaconsSeen += beacons.length;
-  return kanikama.push(beacons);
+  lastRangeAt = Date.now();
+  lastBeacons = beacons;
+
+  var result = kanikama.push(beacons);
+
+  if (beaconDebug !== null) {
+    beaconDebug.update();
+  }
+
+  return result;
+};
+
+/**
+ * 測位まわりの実況
+ *
+ * 実機で「現在地が出ない」と言われたときに、どこで止まっているかを切り分ける。
+ *
+ *   ranging が 0                  → 検出が始まっていない（権限・プラグイン）
+ *   ranging はあるが beacons が 0 → スキャンは回っているが1本も見えていない
+ *   beacons はあるが position が null → 測位アルゴリズムまで届いていない
+ */
+var diagnostics = function () {
+  return {
+    platform: (typeof cordova !== "undefined" && cordova !== null) ? cordova.platformId : "web",
+    ranging: rangingCallbacks,
+    beacons: beaconsSeen,
+    lastRangeAt: lastRangeAt,
+    lastBeacons: lastBeacons,
+    facility: kanikama.currentFacility ? kanikama.currentFacility.id : null,
+    floor: kanikama.currentFloor ? kanikama.currentFloor.id : null,
+    position: kanikama.currentPosition,
+    heading: kanikama.heading
+  };
 };
 
 // スプラッシュを出しておく最短時間（ミリ秒）。ロゴを見せるための下限で、
@@ -429,6 +470,19 @@ var initializeApp = function () {
   window.addEventListener("BluetoothStatus.disabled", invalidateLocator);
   kanikama.facilities_ = rules;
 
+  /*
+   ビーコンの受信状況を画面に出す。**デバッグビルドだけ。**
+
+   実機で測位が出ないとき、USB を繋いで chrome://inspect を開ける状況ばかりでは
+   ないので、端末だけで切り分けられるようにしてある。
+   pointer-events: none なので下のボタンはそのまま押せる。
+   */
+  if (__DEBUG__) {
+    beaconDebug = createBeaconDebug(diagnostics, {
+      ios: typeof cordova !== "undefined" && cordova !== null && cordova.platformId === "ios"
+    });
+  }
+
   // プラットフォームを問わず走らせる。上の cordova ブロックは
   // platformId !== "browser" で括られていて、ブラウザ版はそこを通らない
   scheduleHideSplash();
@@ -635,26 +689,13 @@ export default class App {
   }
 
   /**
-   * 測位まわりの実況を返す
+   * 測位まわりの実況を返す（上の diagnostics() を参照）
    *
-   * 実機で「現在地が出ない」と言われたときに、どこで止まっているかを
-   * その場で切り分けるための入口。Chrome の chrome://inspect から
-   * `app.getDiagnostics()` を叩けば、ビルドし直さずに状態が読める。
-   *
-   *   ranging が 0            → 検出が始まっていない（権限・プラグイン）
-   *   ranging はあるが beacons が 0 → スキャンは回っているが1本も見えていない
-   *   beacons はあるが position が null → 測位アルゴリズムまで届いていない
+   * デバッグビルドでは同じ内容が画面に出ている。こちらは release でも使えるので、
+   * USB を繋げるときは chrome://inspect から `app.getDiagnostics()` で読む。
    */
   getDiagnostics() {
-    return {
-      platform: (typeof cordova !== "undefined" && cordova !== null) ? cordova.platformId : "web",
-      ranging: rangingCallbacks,
-      beacons: beaconsSeen,
-      facility: kanikama.currentFacility ? kanikama.currentFacility.id : null,
-      floor: kanikama.currentFloor ? kanikama.currentFloor.id : null,
-      position: kanikama.currentPosition,
-      heading: kanikama.heading
-    };
+    return diagnostics();
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -186,6 +186,29 @@ var lastBeacons = [];
 /** デバッグビルドでだけ作られる画面表示。release では丸ごと落ちる */
 var beaconDebug = null;
 
+/*
+ デバッグビルドだけ、**UUID を絞らない領域**も並行して測る。
+
+ ranging は領域（UUID）で絞られる。つまり「スキャンは回っているのに0本」は
+ 「BLE が何も拾えていない」とは限らず、**別の UUID のビーコンなら見えている**
+ かもしれない。切り分けるには、絞らない領域で同時に測るしかない。
+
+ AltBeacon は id1 が null の領域を「全部」として扱う。plugin の
+ BeaconRegion.WILDCARD_UUID がそこへ橋渡しする（Android 限定）。
+ */
+var DEBUG_ANY_REGION = "debug-any";
+var anyRanging = 0;
+var anyBeacons = [];
+var probeStatus = "-";
+
+var debugRangedAny = function (beacons) {
+  anyRanging++;
+  anyBeacons = beacons;
+  if (beaconDebug !== null) {
+    beaconDebug.update();
+  }
+};
+
 var didRangeBeaconsInRegion = function (beacons) {
   rangingCallbacks++;
   beaconsSeen += beacons.length;
@@ -340,16 +363,43 @@ var initializeApp = function () {
       locationManager.requestWhenInUseAuthorization();
       delegate = new locationManager.Delegate();
 
-      delegate.didRangeBeaconsInRegion = function (
-        {
-          beacons
-        }) {
-        return didRangeBeaconsInRegion.apply(window, [beacons]);
+      // delegate は1つしか持てないので、どの領域のコールバックかは identifier で分ける
+      delegate.didRangeBeaconsInRegion = function (result) {
+        if (__DEBUG__ && result.region != null && result.region.identifier === DEBUG_ANY_REGION) {
+          return debugRangedAny(result.beacons);
+        }
+        return didRangeBeaconsInRegion.apply(window, [result.beacons]);
       };
 
       locationManager.setDelegate(delegate);
       region = new locationManager.BeaconRegion("sabatomap", "00000000-71C7-1001-B000-001C4D532518");
       locationManager.startRangingBeaconsInRegion(region).fail(console.error);
+
+      if (__DEBUG__) {
+        /*
+         プラグインが見ている状態を画面に出す。getAuthorizationStatus は
+         Android では checkAvailability()（＝BluetoothAdapter.isEnabled()）を
+         見ているだけなので、**BLUETOOTH_CONNECT が無い端末では例外の文言が返る**。
+         それも含めてそのまま出す。何が返るかを知りたいので握り潰さない。
+         */
+        locationManager.getAuthorizationStatus()
+          .then(function (r) {
+            probeStatus = String((r != null ? r.authorizationStatus : null) ?? r);
+          })
+          .fail(function (e) {
+            probeStatus = "取得失敗 " + e;
+          });
+
+        // WILDCARD_UUID は Android だけ。iOS の CLBeaconRegion は UUID 必須
+        if (cordova.platformId === "android") {
+          locationManager
+            .startRangingBeaconsInRegion(
+              new locationManager.BeaconRegion(DEBUG_ANY_REGION, locationManager.BeaconRegion.WILDCARD_UUID))
+            .fail(function (e) {
+              probeStatus = probeStatus + " / 全UUID開始失敗 " + e;
+            });
+        }
+      }
     }
 
     if (navigator.connection != null && navigator.connection.type === "none") {
@@ -478,7 +528,14 @@ var initializeApp = function () {
    pointer-events: none なので下のボタンはそのまま押せる。
    */
   if (__DEBUG__) {
-    beaconDebug = createBeaconDebug(diagnostics, {
+    beaconDebug = createBeaconDebug(function () {
+      var s = diagnostics();
+      // UUID を絞らない領域の分。ここだけ見えているなら UUID 違い
+      s.anyRanging = anyRanging;
+      s.anyBeacons = anyBeacons;
+      s.probe = probeStatus;
+      return s;
+    }, {
       ios: typeof cordova !== "undefined" && cordova !== null && cordova.platformId === "ios"
     });
   }

--- a/src/app.js
+++ b/src/app.js
@@ -200,6 +200,38 @@ var DEBUG_ANY_REGION = "debug-any";
 var anyRanging = 0;
 var anyBeacons = [];
 var probeStatus = "-";
+var geoStatus = "-";
+
+/**
+ * 位置情報の権限と位置情報サービスを、プラグインを足さずに確かめる（デバッグビルド専用）
+ *
+ * Android 12 以降、BLUETOOTH_SCAN に neverForLocation が付いていないと、
+ * **スキャン結果を受け取るのに位置情報の権限と位置情報サービスの両方が要る**。
+ * 足りなくても例外にはならず、結果が空で返るだけなので中からは分からない。
+ *
+ * WebView の geolocation は同じ ACCESS_FINE_LOCATION と位置情報サービスを使う。
+ * ここが通れば、残る容疑は「付近のデバイス」（BLUETOOTH_SCAN）だけに絞れる。
+ *
+ *   1 PERMISSION_DENIED   → アプリに位置情報の権限が無い
+ *   2 POSITION_UNAVAILABLE → 端末の位置情報サービスが切れている
+ *   3 TIMEOUT              → 判定できず（屋内で測位に時間がかかっただけのことも）
+ */
+var probeGeolocation = function () {
+  if (navigator.geolocation == null) {
+    geoStatus = "geolocation なし";
+    return;
+  }
+  geoStatus = "確認中";
+  navigator.geolocation.getCurrentPosition(function () {
+    geoStatus = "許可あり";
+  }, function (e) {
+    geoStatus = "NG(" + e.code + ") " + e.message;
+  }, {
+    timeout: 8000,
+    maximumAge: 0,
+    enableHighAccuracy: true
+  });
+};
 
 var debugRangedAny = function (beacons) {
   anyRanging++;
@@ -528,12 +560,14 @@ var initializeApp = function () {
    pointer-events: none なので下のボタンはそのまま押せる。
    */
   if (__DEBUG__) {
+    probeGeolocation();
     beaconDebug = createBeaconDebug(function () {
       var s = diagnostics();
       // UUID を絞らない領域の分。ここだけ見えているなら UUID 違い
       s.anyRanging = anyRanging;
       s.anyBeacons = anyBeacons;
       s.probe = probeStatus;
+      s.geo = geoStatus;
       return s;
     }, {
       ios: typeof cordova !== "undefined" && cordova !== null && cordova.platformId === "ios"

--- a/src/libs/beacondebug.js
+++ b/src/libs/beacondebug.js
@@ -94,6 +94,8 @@ export default function createBeaconDebug(getState, { ios = false } = {}) {
       }
     }
     lines.push(`プラグイン ${s.probe}`);
+    // 位置情報が通るなら、BLE が空な理由は「付近のデバイス」に絞れる
+    lines.push(`位置情報 ${s.geo}`);
 
     el.textContent = lines.join('\n');
   };

--- a/src/libs/beacondebug.js
+++ b/src/libs/beacondebug.js
@@ -80,6 +80,21 @@ export default function createBeaconDebug(getState, { ios = false } = {}) {
       : `測位 ${p.algorithm}  誤差 ${p.accuracy}m  minor ${p.beacon ? p.beacon.minor : '-'}`);
     lines.push(`方位 ${s.heading === null ? '-' : Math.round(s.heading)}`);
 
+    /*
+     UUID を絞らない領域の分。**上の「見えている」が空でここに出るなら UUID 違い。**
+     どちらも空なら BLE が何も拾えていない（権限・位置情報サービス・電波）。
+     Android だけ動く（iOS の CLBeaconRegion は UUID 必須）ので、
+     数えていないときは出さない。
+     */
+    if (s.anyRanging > 0 || s.anyBeacons.length > 0) {
+      lines.push(`全UUID ${s.anyRanging}回  ${formatBeacons(s.anyBeacons, 3)}`);
+      const uuids = new Set(s.anyBeacons.map((b) => String(b.uuid).toLowerCase()));
+      if (uuids.size > 0) {
+        lines.push(`UUID ${[...uuids].map((u) => u.slice(0, 13)).join(' ')}`);
+      }
+    }
+    lines.push(`プラグイン ${s.probe}`);
+
     el.textContent = lines.join('\n');
   };
 

--- a/src/libs/beacondebug.js
+++ b/src/libs/beacondebug.js
@@ -1,0 +1,97 @@
+/*
+ ビーコンの受信状況を画面に出す（デバッグビルド専用）
+
+ 実機で「現在地が出ない」となったとき、USB を繋いで chrome://inspect を開ける
+ 状況ばかりではない。館内で端末だけを見て切り分けられるようにする。
+
+ tools/build.mjs が `__DEBUG__` を建てたときだけ app.js から呼ばれる。
+ release ビルドでは define と minify で丸ごと落ちる。
+
+ **地図にも操作にも一切かぶらないこと**を優先している。
+ pointer-events: none なので、下にあるボタンはそのまま押せる。
+ 位置はコンパス（top 70px / iOS 90px）に合わせ、右側は空けてある。
+ */
+
+/** 見出しと本文の色。夜の館内でも読めるよう白抜きにする */
+const STYLE = [
+  'position: absolute',
+  'top: 70px',
+  'left: 8px',
+  'max-width: calc(100% - 70px)',
+  'padding: 6px 8px',
+  'border-radius: 4px',
+  'background: rgba(0, 0, 0, 0.72)',
+  'color: #fff',
+  'font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+  'white-space: pre',
+  'pointer-events: none',
+  'user-select: none',
+  '-webkit-user-select: none',
+  // #offline(2000000) より上、スプラッシュ(9000000) より下
+  'z-index: 3000000',
+].join(';');
+
+/** rssi の強い順に minor:rssi を並べる。多いと読めないので上位だけ */
+function formatBeacons(beacons, limit) {
+  if (beacons.length === 0) {
+    return 'なし';
+  }
+  const sorted = beacons.slice().sort((a, b) => b.rssi - a.rssi);
+  const head = sorted.slice(0, limit).map((b) => `${b.minor}:${b.rssi}`).join(' ');
+  return sorted.length > limit ? `${head} ほか${sorted.length - limit}` : head;
+}
+
+/** 経過を「12秒前」「3分前」に。まだ一度も無いときは null */
+function since(at) {
+  if (at === null) {
+    return null;
+  }
+  const sec = Math.round((Date.now() - at) / 1000);
+  return sec < 60 ? `${sec}秒前` : `${Math.round(sec / 60)}分前`;
+}
+
+/**
+ * デバッグ表示を作る
+ *
+ * @param getState {function} 表示するデータを返す。app.js の diagnostics()
+ * @param opts {Object} ios なら位置をずらす
+ * @returns {Object} update() を持つ。呼ぶたびに描き直す
+ */
+export default function createBeaconDebug(getState, { ios = false } = {}) {
+  const el = document.createElement('div');
+  el.id = 'beacon-debug';
+  el.setAttribute('style', ios ? STYLE.replace('top: 70px', 'top: 90px') : STYLE);
+  document.body.appendChild(el);
+
+  const render = () => {
+    const s = getState();
+    const lines = [];
+
+    // ranging が増えていなければ、検出がそもそも始まっていない。
+    // 圏内にビーコンが無くても1秒ごとに呼ばれるので、ここは必ず増える
+    const last = since(s.lastRangeAt);
+    lines.push(`BLE ${s.platform}  ranging ${s.ranging}${last === null ? '（未着）' : `（${last}）`}`);
+    lines.push(`見えている ${formatBeacons(s.lastBeacons, 4)}`);
+    lines.push(`のべ ${s.beacons} 本  施設 ${s.facility ?? '-'}  フロア ${s.floor ?? '-'}`);
+
+    const p = s.position;
+    lines.push(p === null
+      ? '測位 なし'
+      : `測位 ${p.algorithm}  誤差 ${p.accuracy}m  minor ${p.beacon ? p.beacon.minor : '-'}`);
+    lines.push(`方位 ${s.heading === null ? '-' : Math.round(s.heading)}`);
+
+    el.textContent = lines.join('\n');
+  };
+
+  render();
+  // ranging が止まったことも見えるように、受信が無くても回す
+  const timer = setInterval(render, 1000);
+
+  return {
+    update: render,
+    destroy() {
+      clearInterval(timer);
+      el.remove();
+    },
+  };
+}

--- a/test/e2e/shot-debug.mjs
+++ b/test/e2e/shot-debug.mjs
@@ -1,0 +1,46 @@
+/*
+ デバッグビルドのビーコン表示を目で見るための使い捨てスクリプト。
+
+   cd .. && npm run copy:debug && npx cordova prepare browser
+   cd test/e2e && node shot-debug.mjs
+
+ spec ではないので playwright test では拾われない。撮った png は test-results/ へ。
+ */
+import { chromium } from '@playwright/test';
+import { createServer, PORT } from './support/server.mjs';
+import { openApp, pushBeacons, settle } from './support/app.mjs';
+
+const server = createServer();
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r));
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 414, height: 896 }, deviceScaleFactor: 2 });
+
+const { errors } = await openApp(page, PORT);
+
+// 何も受け取っていない状態（実機で「反応しない」ときの見え方）
+await page.screenshot({ path: 'test-results/debug-panel-empty.png' });
+console.log('未受信:', await page.evaluate(() => document.getElementById('beacon-debug')?.textContent));
+
+// 115番を流し込む
+await pushBeacons(page, [
+  { uuid: '00000000-71C7-1001-B000-001C4D532518', major: 105, minor: 115, rssi: -62 },
+  { uuid: '00000000-71C7-1001-B000-001C4D532518', major: 105, minor: 114, rssi: -78 },
+]);
+await settle(page);
+await page.screenshot({ path: 'test-results/debug-panel-ranged.png' });
+console.log('受信後:', await page.evaluate(() => document.getElementById('beacon-debug')?.textContent));
+
+// 下のボタンが押せること（pointer-events: none の確認）
+const blocked = await page.evaluate(() => {
+  const panel = document.getElementById('beacon-debug');
+  const r = panel.getBoundingClientRect();
+  const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+  return hit === panel || panel.contains(hit);
+});
+console.log('パネルがタップを奪っているか:', blocked);
+
+if (errors.length) console.log('エラー:', errors);
+
+await browser.close();
+server.close();

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -114,7 +114,20 @@ function jsOptions({ production }) {
        **development 版が実行されていた**（成果物に Invalid hook call などの
        development 専用文字列が残っていた）。ここで固定して production 版だけにする。
        */
-      define: { 'process.env.NODE_ENV': JSON.stringify(production ? 'production' : 'development') },
+      define: {
+        'process.env.NODE_ENV': JSON.stringify(production ? 'production' : 'development'),
+        /*
+         デバッグビルドでだけ有効になる仕掛けの入口。いまは
+         src/libs/beacondebug.js（ビーコンの受信状況を画面に出す）だけが使う。
+
+         `if (__DEBUG__)` で囲っておくと、release では false に畳まれて
+         minify が枝ごと落とす。**import した先のモジュールも落ちる**ので、
+         デバッグ用のコードが本番の成果物に混ざらない。
+         潰れていることは tools/build.mjs の呼び出し側ではなく成果物で確かめること
+         （release ビルドの www/js/all.js を grep する）。
+         */
+        __DEBUG__: JSON.stringify(!production),
+      },
       /*
        react / react-dom を preact/compat に差し替える。ソースは react のまま書ける。
 

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -14,6 +14,11 @@ export default defineConfig({
       'react/jsx-runtime': 'preact/compat/jsx-runtime',
     },
   },
+  // tools/build.mjs が建てる印。ここでも建てておかないと、src/app.js を
+  // 読み込んだテストが ReferenceError で落ちる。テストは release 相当で見る
+  define: {
+    __DEBUG__: 'false',
+  },
   test: {
     environment: 'jsdom',
     include: ['test/**/*.test.{js,jsx}'],


### PR DESCRIPTION
実機で測位が出ないとき、USB を繋いで `chrome://inspect` を開ける状況ばかりではありません。館内で端末だけを見て切り分けられるようにします。

#184（文言を元に戻す）の上に積んでいます。

## 出るもの

検索欄の下に出ます。

```
BLE android  ranging 128（1秒前）
見えている 115:-62 114:-78
のべ 342 本  施設 7  フロア 7
測位 nearest1  誤差 3m  minor 115
方位 137
```

**`ranging` は圏内にビーコンが無くても1秒ごとに増える**ので、増えているかどうかで意味が変わります。

| 見え方 | 意味 |
|---|---|
| `ranging 0（未着）` | 検出がそもそも始まっていない（権限・プラグイン） |
| `ranging` は増えるが「見えている なし」 | スキャンは回っているが1本も見えていない |
| 見えているのに「測位 なし」 | 測位アルゴリズムまで届いていない |

受信が止まったことも見えるよう、最終受信からの経過（`1秒前` / `3分前`）を出し、ranging が来なくても1秒ごとに描き直します。

## 地図と操作にはかぶらない

`pointer-events: none` なので下のボタンはそのまま押せます。位置はコンパスに合わせて検索欄の下（iOS は +20px）、右側はコンパスのぶん空けてあります。

`elementFromPoint` で、パネルがタップを奪っていないことを実際に確かめました（`shot-debug.mjs` が出力）。

## release には入らない

`tools/build.mjs` が `__DEBUG__` を建てます。release では `false` に畳まれ、`if (__DEBUG__)` の枝ごと minify に落とされて **`beacondebug.js` そのものがバンドルに入りません**。成果物を grep して確認済みです。

| ビルド | www/js/all.js | `beacon-debug` / `見えている` / `createBeaconDebug` |
|---|---|---|
| `npm run copy`（release） | 463.3 KB | いずれも 0 件 |
| `npm run copy:debug` | 4985.1 KB | 入っている |

debug 側が大きいのは minify なし・inline sourcemap つきだからです。配信用ではないので構いません（配信は `android-deploy.yml` が release で作ります）。

## ワークフロー

`android.yml`（debug APK）を `npm run copy:debug` に変えました。release ビルドが通ることは `ci.yml` の `npm run copy` が引き続き見ています。

vitest にも `__DEBUG__: false` を建てました。`src/app.js` を読み込むテストが `ReferenceError` で落ちないようにするためです。

## 見え方の確認

`test/e2e/shot-debug.mjs`。spec ではないので `playwright test` では拾われません。

```
cd .. && npm run copy:debug && npx cordova prepare browser
cd test/e2e && node shot-debug.mjs
```

## 確認

- `npm test` 40件グリーン
- `test/e2e` 16件グリーン（release ビルドを見るので基準画像は変わらない）
