### PR TITLE
fix(android): autobind へ移行して altbeacon を 2.21.2 に上げる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,19 +372,34 @@ ref 指定なしだと `npm install` を実行したタイミングで解決先�
 それと対で意味を持つ状態ファイルを追跡してはいけないためです。以前はコミットされていて、
 中身が `browser 5.0.4 / android 6.4.0 / ios 4.5.5` と2〜9メジャー古いままでした。
 
-## ★ AltBeacon は 2.19 に据え置いています
+## ★ AltBeacon は autobind で使っています。手動 bind に戻さないこと
 
-`CALIL/cordova-plugin-ibeacon` の `src/android/cordova-plugin-ibeacon.gradle` で
-`org.altbeacon:android-beacon-library:2.19` を指しています。**上げないでください。**
+`CALIL/cordova-plugin-ibeacon` の `src/android/LocationManager.java` は
+**autobind**（`startRangingBeacons` / `addRangeNotifier`）で書かれています。
+`bind()` / `unbind()` / `BeaconConsumer` / `setRangeNotifier` /
+`startRangingBeaconsInRegion` は**使わないでください。**
 
-2026-08-03 に 2.21.1 へ上げたところ、**実機がビーコンを1本も検出しなくなりました。**
-2026-08-15 に 2.19 へ戻して復旧しています。
+2026-08 に、これで4日ほど**測位が完全に死にました**。
+
+### 何が起きたか
+
+2026-08-03 に altbeacon を 2.19 → 2.21.1 に上げたところ、実機がビーコンを
+1本も検出しなくなりました。**2.21.2 でも直らず、2.19 に戻すと直る**という状態でした。
+
+原因は版ではなく、**このファイルが 2.19 で廃止された手動 bind の API を
+使い続けていたこと**でした。`CHANGELOG` の 2.19 は "Manual binding/unbinding
+deprecated. (#1046)"。公式の移行ガイドは **"Do not mix old binding methods with
+new autobind methods"** と明記しています。2.19 は「廃止したが動く」版で、
+2.20 以降で実際に壊れました。2026-08-15 に autobind へ移し、2.21.2 で復旧しています。
+
+→ https://altbeacon.github.io/android-beacon-library/autobind.html
 
 ### なぜ気づけなかったか
 
 **CI は最後までグリーンでした。** `android.yml` が見ているのは「APK が組み上がるか」
 だけで、ビーコンを検出できるかは誰も検証していません。実機に入れて館内で試すまで
-分からない種類の退行です。
+分からない種類の退行です。**この版や API を触るときは、ビルドの成否ではなく
+実機での検出で判定してください。**
 
 症状も分かりにくいものでした。
 
@@ -399,18 +414,16 @@ ref 指定なしだと `npm install` を実行したタイミングで解決先�
 例外も警告も出ません。**Android は権限や環境が足りないときエラーではなく
 「空のスキャン結果」を返す**ので、権限の問題と見分けが付かず、そちらを延々と疑いました。
 決め手になったのは「**同じ端末・同じビーコンでストア版は動く**」という一言です。
+実機の不具合は、環境や権限を疑う前に**既知の動く版と1変数ずつ比べる**のが早いです。
 
-### 上げ直してよくなる条件
+### プラグインの上流は 2019年で止まっています
 
-2.21.1 は Maven Central の最新ですが、踏んではいけない版です。
+`petermetz/cordova-plugin-ibeacon` は **Android のコードが 2019-12 から一度も
+変わっていません**（以降は docs / CI / Dependabot のみ）。追随してくれる先が無いので、
+Android 側の手当ては CALIL fork で当てます。
 
-| 版 | |
-|---|---|
-| 2.21.1（2025-01・最新） | Corrected default scan periods |
-| 2.21.2（2026-01・CHANGELOG のみ・**未公開**） | **Fixed broken foreground service startup on Android 15** |
-
-**2.21.2 以降が Maven Central に公開されてから**上げてください。
-そのときも、ビルドが通ることではなく**実機でビーコンを検出できること**で判定します。
+一方 **altbeacon 本体は現役**です（★2910・2026-01 更新）。乗り換え先が無いのではなく、
+これが第一選択で、保守されている `Cap-go/capacitor-ibeacon` も中身は altbeacon です。
 
 ### 切り分けの道具
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "autoprefixer": "^10.5.4",
         "browserslist": "^4.28.8",
-        "com.unarin.cordova.beacon": "github:CALIL/cordova-plugin-ibeacon#e0c446ef625d8e04497973d355904561be29237e",
+        "com.unarin.cordova.beacon": "github:CALIL/cordova-plugin-ibeacon#e03aa41f364d2e6c66f22c7b7dcfe7c025b32fa6",
         "cordova": "^13.0.0",
         "cordova-android": "^15.1.0",
         "cordova-browser": "^7.0.0",
@@ -2761,7 +2761,7 @@
     },
     "node_modules/com.unarin.cordova.beacon": {
       "version": "3.8.1",
-      "resolved": "git+ssh://git@github.com/CALIL/cordova-plugin-ibeacon.git#e0c446ef625d8e04497973d355904561be29237e",
+      "resolved": "git+ssh://git@github.com/CALIL/cordova-plugin-ibeacon.git#e03aa41f364d2e6c66f22c7b7dcfe7c025b32fa6",
       "integrity": "sha512-hqKaA0spo7ISEqDc4zquiVjKupjib2BwgdDXX95Rg/rkXix/8bysYiiNRfWf7kJieDRPb9xOQZ1+7F6vCqapUA==",
       "dev": true,
       "license": "Apache 2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "autoprefixer": "^10.5.4",
         "browserslist": "^4.28.8",
-        "com.unarin.cordova.beacon": "github:CALIL/cordova-plugin-ibeacon#aef7874c2938c7c3ffdb72cb7b6b60ae664dba36",
+        "com.unarin.cordova.beacon": "github:CALIL/cordova-plugin-ibeacon#e0c446ef625d8e04497973d355904561be29237e",
         "cordova": "^13.0.0",
         "cordova-android": "^15.1.0",
         "cordova-browser": "^7.0.0",
@@ -2761,8 +2761,8 @@
     },
     "node_modules/com.unarin.cordova.beacon": {
       "version": "3.8.1",
-      "resolved": "git+ssh://git@github.com/CALIL/cordova-plugin-ibeacon.git#aef7874c2938c7c3ffdb72cb7b6b60ae664dba36",
-      "integrity": "sha512-z7s+/pCOWUotCnrrnl58Hutm485Zyw0bzYpkHbNixIeeGpWNxLqEqRkiqTWqhQVhw4jJmJKvBAYQseA1jfcJxA==",
+      "resolved": "git+ssh://git@github.com/CALIL/cordova-plugin-ibeacon.git#e0c446ef625d8e04497973d355904561be29237e",
+      "integrity": "sha512-hqKaA0spo7ISEqDc4zquiVjKupjib2BwgdDXX95Rg/rkXix/8bysYiiNRfWf7kJieDRPb9xOQZ1+7F6vCqapUA==",
       "dev": true,
       "license": "Apache 2.0"
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "autoprefixer": "^10.5.4",
     "browserslist": "^4.28.8",
-    "com.unarin.cordova.beacon": "github:CALIL/cordova-plugin-ibeacon#e0c446ef625d8e04497973d355904561be29237e",
+    "com.unarin.cordova.beacon": "github:CALIL/cordova-plugin-ibeacon#e03aa41f364d2e6c66f22c7b7dcfe7c025b32fa6",
     "cordova": "^13.0.0",
     "cordova-android": "^15.1.0",
     "cordova-browser": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "autoprefixer": "^10.5.4",
     "browserslist": "^4.28.8",
-    "com.unarin.cordova.beacon": "github:CALIL/cordova-plugin-ibeacon#aef7874c2938c7c3ffdb72cb7b6b60ae664dba36",
+    "com.unarin.cordova.beacon": "github:CALIL/cordova-plugin-ibeacon#e0c446ef625d8e04497973d355904561be29237e",
     "cordova": "^13.0.0",
     "cordova-android": "^15.1.0",
     "cordova-browser": "^7.0.0",


### PR DESCRIPTION
実機がビーコンを検出しなくなっていた件の根治です。**#186 の 2.19 据え置きを置き換えます。**

## 原因は版ではなく、使っていた API だった

2.19 → 2.21.1 で壊れ、2.21.2 でも直りませんでした。版そのものではなく、**プラグインの `LocationManager.java` が 2.19 で廃止された手動 bind の API を使い続けていたこと**が原因です。

`CHANGELOG` の 2.19 は "Manual binding/unbinding deprecated. (#1046)"。公式の移行ガイドは **"Do not mix old binding methods with new autobind methods"** と明記しています。2.19 は「廃止したが動く」版で、2.20 以降で実際に壊れた、という筋が通ります。

上流の `petermetz/cordova-plugin-ibeacon` は **Android のコードが 2019-12 から一度も変わっていない**ので、追随してくれる先はありません。fork で当てます。

## 変更

fork 側: CALIL/cordova-plugin-ibeacon の `fix/altbeacon-autobind`（`e0c446e`）

| いま | これから |
|---|---|
| `implements BeaconConsumer` | 外す |
| `bind(this)` / `unbind(this)` | 削除（autobind に任せる） |
| `startRangingBeaconsInRegion(r)` | `startRangingBeacons(r)` |
| `stopRangingBeaconsInRegion(r)` | `stopRangingBeacons(r)` |
| `startMonitoringBeaconsInRegion(r)` | `startMonitoring(r)` |
| `stopMonitoringBeaconsInRegion(r)` | `stopMonitoring(r)` |
| `setRangeNotifier(n)` | `removeAllRangeNotifiers()` + `addRangeNotifier(n)` |
| `setMonitorNotifier(n)` | `removeAllMonitorNotifiers()` + `addMonitorNotifier(n)` |
| `catch (RemoteException)` 4箇所 | 削除（新 API は投げない） |
| `onBeaconServiceConnect` / `bindService` / `unbindService` | 削除 |
| altbeacon | 2.19 → **2.21.2** |

気をつけた点が3つあります。

- **notifier は単純に `add` へ置き換えていません。** `set` は「全部消してから足す」で、`createRangingCallbacks` は JS から呼べる `registerDelegateCallbackId` 経由なので複数回走りえます。`removeAll` してから `add` して元の意味を保っています
- **`getApplicationContext()` は残しました。** `BeaconConsumer` の一部でしたが、`createOrGetBeaconTransmitter` が `BeaconTransmitter` を作るのに使っています
- **iBeacon のパーサ登録は据え置き。** 既定は AltBeacon 形式で iBeacon は含まれないので、これが無いと1本も検出しません

## マージの条件

**実機でビーコンを検出できることを確かめるまでマージしないでください。** 2026-08 の事故では CI が最後までグリーンでした。`android.yml` は APK が組み上がるかしか見ていません。

判定はデバッグ表示（#185）の「見えている」行で行います。

通らなければこの PR は捨て、`master` は 2.19 据え置きのままにします。