### PR TITLE
fix(ci): 内部アプリ共有のビルドに --packageType=apk を明示する

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -206,6 +206,10 @@ jobs:
       #
       # internal トラックは Play の通常の配信経路なので AAB が要る
       # （2021年8月以降、新規リリースは AAB のみ）
+      #
+      # **--packageType は両方に明示すること。** cordova-android は --release の
+      # 既定が bundle で、省くと internalsharing でも AAB が焼かれる。
+      # 次の「できたものを確認」が APK を探して落ちる（2026-08-15 に6回連続で失敗）
       - name: 成果物を組む
         env:
           TRACK: ${{ github.event.inputs.track || 'internalsharing' }}
@@ -213,7 +217,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$TRACK" = "internalsharing" ]; then
-            npx cordova build android --release --buildConfig build-ci.json -- ${VERSION_CODE_ARG:-}
+            npx cordova build android --release --buildConfig build-ci.json -- --packageType=apk ${VERSION_CODE_ARG:-}
           else
             npx cordova build android --release --buildConfig build-ci.json -- --packageType=bundle ${VERSION_CODE_ARG:-}
           fi


### PR DESCRIPTION
**配信ワークフローが #182 のマージ以降、6回連続で失敗していました。**

## 原因

`cordova-android` は `--release` の既定が **bundle** です。internalsharing 側は `--packageType` を省いていたので AAB が焼かれ、次の「できたものを確認」が APK を探して落ちていました。

```
Built the following bundle(s): .../app-release.aab
find: 'platforms/android/app/build/outputs/apk': No such file or directory
```

## なぜ気づけなかったか

`android-deploy.yml` は **`push`(master) と `workflow_dispatch` でしか走りません。** PR の CI では一度も実行されないので、#182 は緑のままマージされました。

`ci.yml` / `android.yml` が緑でも、このワークフローは検証されていません。

## 変更

両方の分岐に `--packageType` を明示し、省略時の既定に依存しない形にしました。理由もコメントに残しています。

```diff
   if [ "$TRACK" = "internalsharing" ]; then
-    npx cordova build android --release --buildConfig build-ci.json -- ${VERSION_CODE_ARG:-}
+    npx cordova build android --release --buildConfig build-ci.json -- --packageType=apk ${VERSION_CODE_ARG:-}
   else
     npx cordova build android --release --buildConfig build-ci.json -- --packageType=bundle ${VERSION_CODE_ARG:-}
   fi
```

## 確認

マージ後、master への push で自動的に走ります。そこで通ることを確認します。

なお、**内部アプリ共有の「ダウンロードできません」は別件で未解決**です。この修正は配信ワークフローが最後まで走るようにするもので、Play 側の配信が直るとは限りません。詰まる場合は「成果物を残す」で APK が artifact に出るので、そこから直接インストールできます。