### PR TITLE
fix(ci): デバッグ鍵を run をまたいで使い回す（毎回のアンインストールをなくす）

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,6 +64,37 @@ jobs:
             platforms;android-36
             build-tools;36.0.0
 
+      # デバッグ鍵を run をまたいで使い回す。
+      #
+      # ランナーは毎回まっさらなコンテナで ~/.android/debug.keystore が無い。
+      # 放っておくと **Gradle がビルドごとに違う鍵を自動生成する**ので、
+      # 焼き上がる APK の署名が毎回変わり、実機では前のものを
+      # アンインストールしないと入らない。館内で試すときに毎回これをやることになる。
+      #
+      # 鍵そのものは秘密ではない（Android SDK が誰の手元でも自動生成するもの）。
+      # 中身を追跡すると public リポジトリに鍵が乗るので、キャッシュで持ち回す。
+      # 落ちても次のステップが作り直すだけなので、失敗しても止めない。
+      - name: デバッグ鍵を復元する
+        id: debug-keystore
+        uses: actions/cache@v4
+        with:
+          path: ~/.android/debug.keystore
+          key: android-debug-keystore-v1
+
+      - name: 無ければデバッグ鍵を作る
+        if: steps.debug-keystore.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.android
+          # Android SDK が既定で使うのと同じパラメータ
+          keytool -genkeypair -v \
+            -keystore ~/.android/debug.keystore \
+            -storepass android -keypass android \
+            -alias androiddebugkey \
+            -dname "CN=Android Debug,O=Android,C=US" \
+            -keyalg RSA -keysize 2048 -validity 10950
+          echo "新しいデバッグ鍵を作りました。次回からはキャッシュから復元されます"
+
       # cordova は wrapper を「システムの gradle で」作る。
       # ubuntu-latest には最初から入っているが、このランナーには無いので入れる。
       # 版は cordova-android の cdv-gradle-config-defaults.json に合わせてある。


### PR DESCRIPTION
実機に入れるとき、**毎回アンインストールしないとインストールできない**状態でした。

## 原因

ランナーは毎回まっさらなコンテナで `~/.android/debug.keystore` がありません。放っておくと **Gradle がビルドごとに違うデバッグ鍵を自動生成する**ので、焼き上がる APK の署名が毎回変わります。Android は署名の異なる APK を上書きできないので、館内で試すたびにアンインストールが必要になっていました。

今回の測位の切り分けで何度も APK を入れ替えたため、その都度この手間がかかっていました。

## 変更

`actions/cache` で `~/.android/debug.keystore` を持ち回し、無ければ Android SDK と同じパラメータで作ります。

```
-alias androiddebugkey -storepass android -keypass android
-dname "CN=Android Debug,O=Android,C=US"
```

**鍵そのものは秘密ではありません**（Android SDK が誰の手元でも自動生成するものです）。ただし中身を追跡すると public リポジトリに鍵が乗るので、キャッシュで持ち回す形にしました。

キャッシュが落ちても次のステップが作り直すだけなので、ビルドは止まりません。その回だけまたアンインストールが必要になります。

## 効果の範囲

`android.yml`（debug APK）だけです。`android-deploy.yml` は release keystore を secrets から展開しているので元から安定しています。

**デバッグ APK と release APK / ストア版の間は、引き続き行き来のたびにアンインストールが要ります。** 署名が別物なので避けられません。実機確認はどちらか一方に寄せるのが楽です。