### PR TITLE
perf(android): ranging の張り直しを 1.5 秒から始める

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -290,10 +290,15 @@ var restartRanging = function () {
 /**
  * まだ1本も見ていなければ ranging を張り直す
  *
- * 間隔を空けて数回。1本でも見えたら以降は何もしない（館外では無駄に走らせない）。
+ * **1回目を早くするほど測位が早く出る。** 3秒始まりのときは実機で
+ * 起動から5秒ほどかかっていた（3秒＋スキャン周期 1.1秒）。
+ * 束縛はそれより前に終わっているので 1.5 秒から始める。
+ * 仮に早すぎて空振りしても、後続がそのまま効くので害はない。
+ *
+ * 1本でも見えたら以降は何もしない（館外では無駄に走らせない）。
  */
 var scheduleRangingRetries = function () {
-  for (const delay of [3000, 8000, 20000]) {
+  for (const delay of [1500, 3500, 8000, 20000]) {
     rangingRetryTimers.push(setTimeout(function () {
       if (beaconsSeen === 0) {
         restartRanging();


### PR DESCRIPTION
#192 で初回起動の測位は直りましたが、**実機で起動から5秒ほど**かかっていました。3秒後の1回目 ＋ スキャン周期 1.1 秒でほぼ説明が付きます。

autobind の束縛はそれより前に終わっているので、1回目を **1.5 秒**に前倒しします。2〜3秒で測位に入る見込みです。

```diff
- for (const delay of [3000, 8000, 20000]) {
+ for (const delay of [1500, 3500, 8000, 20000]) {
```

**仮に早すぎて空振りしても害はありません。** 後続（3.5 / 8 / 20 秒）がそのまま効きます。1本でも見えたらタイマーを畳むのも従来どおりで、館外で無駄に走ることはありません。

`npm test` 40件・e2e 16件ともグリーン。成果物に `[1500,3500,8e3,2e4]` が入っていることを確認済みです。