### PR TITLE
chore(deps): Dependabot の npm 対象に test/e2e を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,15 @@ version: 2
 updates:
   # ---------------------------------------------------------------------------
   # npm
+  #   "/"          : アプリ本体
+  #   "/test/e2e"  : playwright の e2e。本番の依存を汚さないため独立した package.json
+  #                  になっており、ルートの lockfile では管理されない
+  # directories 指定はディレクトリごとに PR が分かれるので、両者は別々の PR になる
   # ---------------------------------------------------------------------------
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/test/e2e"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## 何をしたか

`.github/dependabot.yml` の npm の対象に `/test/e2e` を追加します。

## なぜ必要か

`test/e2e` は **本番の依存を汚さないよう独立した `package.json` / `package-lock.json`** を持っています（CLAUDE.md にも「独立した package.json です」と明記）。ルートの lockfile では管理されないため、`@playwright/test`（現在 `^1.62.1`）の更新が Dependabot にまったく拾われていませんでした。

地図の描画は jsdom では検証できず e2e でしか見ていない、という構成上、playwright は退行検知の要になっています。ここが更新されないままなのは避けたいところです。

## workspaces ではないので個別指定してよい

npm のモノレポでは、**workspaces の子ディレクトリを `directories` に個別指定すると共有 lockfile が更新されず、`mergeable: clean` でもマージ後に `npm ci` が壊れる**という既知の問題があります。

sabatomap のルート `package.json` には `workspaces` フィールドが無く、`test/e2e` は自前の `package-lock.json` を持つ完全に独立したプロジェクトなので、この問題には該当しません。

## 影響範囲

`directories` はディレクトリごとに PR が分かれるため、ルートと `/test/e2e` の更新は別々の PR になります。既存の `ignore`（react / react-dom の major）と `groups`（minor/patch をまとめる）は両方に適用されますが、`test/e2e` の依存は `@playwright/test` だけなので実質的な影響はありません。

## 背景

CALIL org 全体で「マニフェストはあるのに Dependabot の対象になっていないディレクトリ」を洗い出した結果、対応が必要と判断したものの1つです。
